### PR TITLE
Use best practices for determining the size of an array element

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -71,7 +71,7 @@ Note que `sizeof` retorna o número total de bytes. Então, para os tipos de dad
 
 [source,arduino]
 ----
-for (i = 0; i < (sizeof(meusInts)/sizeof(int)); i++) {
+for (i = 0; i < (sizeof(meusInts)/sizeof(meusInts[0])); i++) {
   // faz algo com meusInts[i]
 }
 ----


### PR DESCRIPTION
The previous code does not automatically adapt to changes in the type of `meusInts`.

Reference: https://github.com/arduino/reference-en/commit/b0791f1b26e33b290b0660f664cf3cae5a350cca