### PR TITLE
Use Serial instead of Serial1 in Mouse.isPressed() example

### DIFF
--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -64,7 +64,7 @@ void setup(){
   pinMode(3,INPUT);
   
   // inicia a comunicação serial com o computador
-  Serial1.begin(9600);
+  Serial.begin(9600);
   
   // inicia a biblioteca Mouse
   Mouse.begin();
@@ -87,7 +87,7 @@ void loop(){
   }
   
   // imprime o estado atual do botão do mouse emulado
-  Serial1.println(mouseState);
+  Serial.println(mouseState);
   delay(10);
 }
 ----


### PR DESCRIPTION
It's highly unlikely a user would want Serial1.

Fixes https://github.com/arduino/reference-pt/issues/197