### PR TITLE
Fixing sizeof doesn't highlight sizeof keyword

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -12,7 +12,7 @@ subCategories: [ "Utilitários" ]
 
 [float]
 === Descrição
-O operador sizeof retorna o número de bytes de uma variável, ou o número de bytes ocupados em um vetor.
+O operador `sizeof` retorna o número de bytes de uma variável, ou o número de bytes ocupados em um vetor.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/437

Fixes https://github.com/arduino/reference-pt/issues/205