### PR TITLE
fenced functions mentioned in text with backticks to render them as <code>

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -49,7 +49,7 @@ Supomos que você quisesse ter certeza que um programa sempre captura os pulsos 
 == Sobre Rotinas de Serviço de Interrupções (ISRs)
 ISRs são tipos especiais de funções que possuem  algumas limitações únicas que as outras funções não possuem. Uma ISR não recebe argumentos, e não devem retornar nada.
 
-Geralmente, uma ISR deve ser o mais curta e rápida possível. Se o seu sketch usa múltiplas ISRs, apenas uma pode ser executada de cada vez, outras interrupções serão executadas após a atual terminar, em uma ordem que depende de sua prioridade. `millis()` depende de interrupções para contar, então essa nunca irá incrementar dentro de uma ISR. Como `delay()` também depende de interrupções, não irá funcionar dentro de uma ISR. micros() funciona inicialmente, mas começará a se comportar erraticamente após 1-2 ms. `delayMicroseconds()` não usa nenhum contador, então funciona normalmente.
+Geralmente, uma ISR deve ser o mais curta e rápida possível. Se o seu sketch usa múltiplas ISRs, apenas uma pode ser executada de cada vez, outras interrupções serão executadas após a atual terminar, em uma ordem que depende de sua prioridade. `millis()` depende de interrupções para contar, então essa nunca irá incrementar dentro de uma ISR. Como `delay()` também depende de interrupções, não irá funcionar dentro de uma ISR. `micros()` funciona inicialmente, mas começará a se comportar erraticamente após 1-2 ms. `delayMicroseconds()` não usa nenhum contador, então funciona normalmente.
 
 Tipicamente variáveis globais são usadas para passar dados entre uma ISR e o programa principal. Tenha certeza que variáveis compartilhadas entre uma ISR e o programa principal são atualizadas corretamente, para isso, as declare usando o modificador `volatile`.
 
@@ -121,7 +121,7 @@ Normalmente você deve usar `digitalPinToInterrupt(pino)`, em vez de colocar dir
 
 Mesmo assim, sketches mais antigos frequentemente têm os números das interrupções usados diretamente. Frequentemente o número 0 (para o pino digital 2) ou o número 1 (para o pino digital 3) foram usados. A tabela abaixo mostra os pinos com interrupções disponíveis em cada placa.
 
-Note que na tabela abaixo, os números das interrupções se referem aos números a serem passados para `attachInterrupt()`. Por razões históricas, essa numeração nem sempre corresponde diretamente a numeração do chip atmega (ex. int.0 corresponde à INT4 no chip Atmega2560).
+Note que na tabela abaixo, os números das interrupções se referem aos números a serem passados para `attachInterrupt()`. Por razões históricas, essa numeração nem sempre corresponde diretamente a numeração do chip ATmega (ex. int.0 corresponde à INT4 no chip ATmega2560).
 
 [options="header"]
 |===================================================


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-pt/issues/209