### PR TITLE
Add missing "See also" sections

### DIFF
--- a/Language/Functions/Advanced IO/noTone.adoc
+++ b/Language/Functions/Advanced IO/noTone.adoc
@@ -48,3 +48,14 @@ Se você quiser tocar tons diferentes em múltiplos pinos, você precisa chamar 
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -69,3 +69,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -74,3 +74,14 @@ Essa função depende da função micros(), então não pode ser usada quando in
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftIn.adoc
+++ b/Language/Functions/Advanced IO/shiftIn.adoc
@@ -45,3 +45,14 @@ O valor lido (byte).
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftOut.adoc
+++ b/Language/Functions/Advanced IO/shiftOut.adoc
@@ -127,3 +127,14 @@ shiftOut(dataPin, clock, LSBFIRST, (data >> 8));
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bit.adoc
+++ b/Language/Functions/Bits and Bytes/bit.adoc
@@ -36,3 +36,14 @@ O valor do bit.
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitClear.adoc
+++ b/Language/Functions/Bits and Bytes/bitClear.adoc
@@ -38,3 +38,14 @@ Nada
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitRead.adoc
+++ b/Language/Functions/Bits and Bytes/bitRead.adoc
@@ -39,3 +39,14 @@ O valor do bit (0 ou 1).
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitSet.adoc
+++ b/Language/Functions/Bits and Bytes/bitSet.adoc
@@ -38,3 +38,14 @@ Nada
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitWrite.adoc
+++ b/Language/Functions/Bits and Bytes/bitWrite.adoc
@@ -40,3 +40,14 @@ Nada
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -135,3 +135,14 @@ Para as placas Due, Zero, MKR1000 e 101 o *número da interrupção = número do
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -34,3 +34,14 @@ Nada
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -55,3 +55,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -56,3 +56,14 @@ a++;        // manter a aritmética fora da função
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -60,3 +60,14 @@ sensVal = constrain(sensVal, 10, 150);    // limita os valores entre 10 e 150
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -95,3 +95,14 @@ long map(long x, long in_min, long in_max, long out_min, long out_max)
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -68,3 +68,14 @@ a--;           // manter a aritmética fora da função
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -69,3 +69,14 @@ a++;             // manter a aritmética fora da função
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -31,3 +31,14 @@ O quadrado do número. (double)
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sqrt.adoc
+++ b/Language/Functions/Math/sqrt.adoc
@@ -32,3 +32,14 @@ A raiz quadrada do número. (double)
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Random Numbers/random.adoc
+++ b/Language/Functions/Random Numbers/random.adoc
@@ -87,3 +87,14 @@ O parâmetro `max` deve ser escolhido de acordo com o tipo de dado da variável 
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Random Numbers/randomSeed.adoc
+++ b/Language/Functions/Random Numbers/randomSeed.adoc
@@ -69,3 +69,14 @@ void loop(){
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -78,3 +78,14 @@ A partir da versão Arduino 0018, delayMicroseconds() não mais desativa interru
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -70,3 +70,14 @@ Há 1000 (mil) microssegundos em um milissegundo e 1000000 (um milhão) de micro
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Structure/Sketch/loop.adoc
+++ b/Language/Structure/Sketch/loop.adoc
@@ -52,3 +52,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Structure/Sketch/setup.adoc
+++ b/Language/Structure/Sketch/setup.adoc
@@ -51,3 +51,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -34,3 +34,14 @@ O trecho de código abaixo cria uma variável do tipo word.
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -78,3 +78,14 @@ for (i = 0; i < (sizeof(meusInts)/sizeof(int)); i++) {
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Variable Scope & Qualifiers/scope.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/scope.adoc
@@ -63,3 +63,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
When the "See also" section is missing, the automatically generated links to the other pages within the same subsection are added to a section titled "undefined".

Fixes https://github.com/arduino/reference-pt/issues/229