### PR TITLE
Always use capital s when referring to String objects

### DIFF
--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -19,10 +19,7 @@ Converte o conteúdo de um objeto String para uma string estilo C, terminada em 
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.c_str()
-----
+`minhaString.c_str()`
 
 [float]
 === Parâmetros

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -19,14 +19,11 @@ Acessa um caractere em uma determinada posição na String.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.charAt(n)
-----
+`minhaString.charAt(n)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 `n`: a posição do caractere a ser lido da String
 

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -19,25 +19,22 @@ Compara duas Strings, testando se uma vem antes da outra na tabela ASCII, ou se 
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.compareTo(string2)
-----
+`minhaString.compareTo(minhaString2)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
-`string2`: outra variável do tipo String
+`minhaString2`: outra variável do tipo String
 
 
 [float]
 === Retorna
-`um número negativo`: se string vem antes de string2
+`um número negativo`: se minhaString vem antes de minhaString2
 
-`0`: se string é igual a string2
+`0`: se minhaString é igual a minhaString2
 
-`um número positivo`: se string vem depois de string2
+`um número positivo`: se minhaString vem depois de minhaString2
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -19,10 +19,7 @@ Adiciona o parâmetro ao final da String.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.concat(param)
-----
+`minhaString.concat(param)`
 
 [float]
 === Parâmetros

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -19,21 +19,18 @@ Testa se uma String termina ou não com os caracteres de outra String.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.endsWith(string2)
-----
+`minhaString.endsWith(minhaString2)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
-`string2`: outra variável do tipo String
+`minhaString2`: outra variável do tipo String
 
 
 [float]
 === Retorna
-`true`: se string termina com os carcateres de string2
+`true`: se minhaString termina com os carcateres de minhaString2
 
 `false`: do contrário
 

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -19,19 +19,16 @@ Verifica se duas Strings são iguais. A comparação é case-sensitive (letras m
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.equals(string2)
-----
+`minhaString.equals(minhaString2)`
 
 [float]
 === Parâmetros
-`string, string2`: variáveis do tipo String
+`minhaString, minhaString2`: variáveis do tipo String
 
 
 [float]
 === Retorna
-`true`: se string é igual a string2 
+`true`: se minhaString é igual a minhaString2 
 
 `false`: do contrário
 --

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -19,19 +19,16 @@ Verifica se duas strings são iguais. A comparação, nesse caso, não é case-s
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.equalsIgnoreCase(string2)
-----
+`minhaString.equalsIgnoreCase(minhaString2)`
 
 [float]
 === Parâmetros
-`string, string2`: vvariáveis do tipo String
+`minhaString, minhaString2`: vvariáveis do tipo String
 
 
 [float]
 === Retorna
-`true`: se string é igual a string2 (sem diferenciar maiúsculas e minúsculas) 
+`true`: se minhaString é igual a minhaString2 (sem diferenciar maiúsculas e minúsculas) 
 
 `false`: otherwise
 --

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -20,14 +20,11 @@ Copia os caracteres da String para o buffer fornecido.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.getBytes(buf, len)
-----
+`minhaString.getBytes(buf, len)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 `buf`: o buffer no qual os caracteres devem ser copiados (_byte []_)
 

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -20,16 +20,12 @@ Localiza um caractere ou String dentro de outra String. Por padrão, busca desde
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.indexOf(string2)
-
-string.indexOf(string2, desde)
-----
+`minhaString.indexOf(string2)` +
+`minhaString.indexOf(string2, desde)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 `string2`: a string a ser procurada - char ou String
 
@@ -37,7 +33,7 @@ string.indexOf(string2, desde)
 
 [float]
 === Retorna
-A posição da string especificada dentro do objeto String, ou -1 se não for encontrada.
+A posição da minhaString especificada dentro do objeto String, ou -1 se não for encontrada.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -19,16 +19,12 @@ Localiza um caractere ou String dentro de outra String. Por padrão, busca desde
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.lastIndexOf(string2)
-
-string.lastIndexOf(string2, desde)
-----
+`minhaString.lastIndexOf(string2)` +
+`minhaString.lastIndexOf(string2, desde)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 `string2`: a string a ser procurada - char ou String
 

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -19,14 +19,11 @@ Retorna o comprimento da String, em caracteres. (Note que isso não inclui carac
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.length()
-----
+`minhaString.length()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -19,12 +19,8 @@ Modifica uma String, removendo os caracteres a partir de determinado índice at�
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.remove(index)
-
-string.remove(index, count)
-----
+`minhaString.remove(index)` +
+`minhaString.remove(index, count)`
 
 [float]
 === Parâmetros

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -19,14 +19,11 @@ A função replace() permite substituir todas as instâncias de um determinado c
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.replace(substring1, substring2)
-----
+`minhaString.replace(substring1, substring2)`
 
 [float]
 === Parâmetros
-`string`: Uma variável do tipo String
+`minhaString`: Uma variável do tipo String
 
 `substring1`: Outra variável do tipo String
 

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -19,10 +19,7 @@ A função reserve() permite alocar um buffer de memória no objeto String para 
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.reserve(tamanho)
-----
+`minhaString.reserve(tamanho)`
 
 [float]
 === Parâmetros

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -20,14 +20,11 @@ Coloca um caractere em determinada posição da String. Não tem efeito em índi
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.setCharAt(index, c)
-----
+`minhaString.setCharAt(index, c)`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 `index`: a posição a se escrever o caractere
 
 `c`: o caractere a ser armazenado na posição dada

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -19,19 +19,16 @@ Testa se uma String começa ou não com os caracteres de uma outra String.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.startsWith(string2)
-----
+`minhaString.startsWith(minhaString2)`
 
 [float]
 === Parâmetros
-`string, string2`: variáveis do tipo String
+`minhaString, minhaString2`: variáveis do tipo String
 
 
 [float]
 === Retorna
-`true`: se string começa com os carcateres de string2
+`true`: se minhaString começa com os carcateres de minhaString2
 
 `false`: do contrário
 --

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -20,16 +20,13 @@ Retorna uma substring de uma String. O índice do início é inclusivo (o caract
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.substring(inicio)
-
-string.substring(inicio, fim)
+`minhaString.substring(inicio)` +
+`minhaString.substring(inicio, fim)`
 ----
 
 [float]
 === Parâmetros
-`string`: a variable of type String
+`minhaString`: a variable of type String
 
 `inicio`: o índice no qual começar a substring (inclusivo)
 

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -20,14 +20,11 @@ Copia os caracteres da String para o buffer fornecido.
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.toCharArray(buf, compr)
-----
+`minhaString.toCharArray(buf, compr)`
 
 [float]
 === Parâmetros
-`string`: umavariável do tipo String
+`minhaString`: umavariável do tipo String
 
 `buf`: the buffer no qual os caracteres devem ser copiados(_char []_)
 

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -19,14 +19,11 @@ Converte uma String válida para um float. A String fornecida deve começar com 
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.toFloat()
-----
+`minhaString.toFloat()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -19,14 +19,11 @@ Converte uma String válida para um valor inteiro. A String deve começar com um
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.toInt()
-----
+`minhaString.toInt()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -19,14 +19,11 @@ Converte uma String para sua versão composta apenas de letras minúsculas. Ante
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.toLowerCase()
-----
+`minhaString.toLowerCase()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -18,14 +18,11 @@ Converte uma String para sua versão composta apenas de letras maiúsculas. Ante
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.toUpperCase()
-----
+`minhaString.toUpperCase()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -19,14 +19,11 @@ Remove quaisquer espaços no começo ou final da String. Antes da versão 1.0, t
 
 [float]
 === Sintaxe
-[source,arduino]
-----
-string.trim()
-----
+`minhaString.trim()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -24,12 +24,12 @@ Acrescenta uma String no final de outra.
 === Sintaxe
 [source,arduino]
 ----
-string += string2
+minhaString += string2
 ----
 
 [float]
 === Parâmetros
-Nenhum
+`minhaString` - uma variável do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -22,12 +22,12 @@ Verifica se duas Strings são iguais. A comparação é case-sensitive (letras m
 === Sintaxe
 [source,arduino]
 ----
-string1 == string2
+minhaString1 == minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2` - variáveis do tipo String
+`minhaString1, minhaString2` - variáveis do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -22,12 +22,12 @@ Combina, ou concatena duas Strings em uma única String. A segunda String é ane
 === Sintaxe
 [source,arduino]
 ----
-string3 = string1 + string 2; string3 += string2;
+minhaString3 = minhaString1 + minhaString2
 ----
 
 [float]
 === Parâmetros
-`string, string1, string2, string3` - variáveis do tipo String
+`minhaString1, minhaString2, minhaString3` - variáveis do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -23,12 +23,12 @@ Verifica se duas Strings são diferentes. A comparação é case-sensitive (letr
 === Sintaxe
 [source,arduino]
 ----
-string1 != string2
+minhaString1 != minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2` - variáveis do tipo String
+`minhaString1, minhaString2` - variáveis do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -22,14 +22,14 @@ Permite acessar os caracteres de uma String individualmente.
 === Sintaxe
 [source,arduino]
 ----
-char thisChar = string1[n]
+char thisChar = minhaString1[n]
 ----
 
 [float]
 === Parâmetros
 `char thisChar` - uma variável char
 
-`string1` - uma variável String
+`minhaString1` - uma variável String
 
 `int n` - a posição do caractere a ser lido da String
 

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -23,12 +23,12 @@ Cuidado: Operadores de comparação de Strings podem ser confusos quando você e
 === Sintaxe
 [source,arduino]
 ----
-string1 > string2
+minhaString1 > minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2` - variáveis do tipo String
+`minhaString1, minhaString2` - variáveis do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -23,12 +23,12 @@ Cuidado: Operadores de comparação de Strings podem ser confusos quando você e
 === Sintaxe
 [source,arduino]
 ----
-string1 >= string2
+minhaString1 >= minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2`: variáveis do tipo String
+`minhaString1, minhaString2`: variáveis do tipo String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -24,12 +24,12 @@ Cuidado: Operadores de comparação de Strings podem ser confusos quando você e
 === Sintaxe
 [source,arduino]
 ----
-string1 < string2
+minhaString1 < minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2`: variáveis do tipo String
+`minhaString1, minhaString2`: variáveis do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -24,12 +24,12 @@ Cuidado: Operadores de comparação de Strings podem ser confusos quando você e
 === Sintaxe
 [source,arduino]
 ----
-string1 <= string2
+minhaString1 <= minhaString2
 ----
 
 [float]
 === Parâmetros
-`string1, string2`: variáveis do tipo String
+`minhaString1, minhaString2`: variáveis do tipo String
 
 [float]
 === Retorna


### PR DESCRIPTION
Beginners are frequently confused about String vs strings so it's important to make a clear distinction between the two in the documentation.

Fixes https://github.com/arduino/reference-pt/issues/233