### PR TITLE
Remove empty "Notes and Warnings" section from Serial.findUntil()

### DIFF
--- a/Language/Functions/Communication/Serial/findUntil.adoc
+++ b/Language/Functions/Communication/Serial/findUntil.adoc
@@ -37,19 +37,6 @@ Se a string foi ou não encontrada no buffer - `bool`
 // OVERVIEW SECTION ENDS
 
 
-
-
-// HOW TO USE SECTION STARTS
-[#howtouse]
---
-
-[float]
-=== Notas e Advertências
-
---
-// HOW TO USE SECTION ENDS
-
-
 // SEE ALSO SECTION
 [#see_also]
 --


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-pt/issues/238