### PR TITLE
Correct function name in "See Also" link

### DIFF
--- a/Language/Functions/Communication/Serial/readBytesUntil.adoc
+++ b/Language/Functions/Communication/Serial/readBytesUntil.adoc
@@ -48,7 +48,7 @@ o número de bytes colocados no buffer (`size_t`)
 
 [role="language"]
 #LINGUAGEM# link:../../stream[Stream] +
-#LINGUAGEM# link:../../stream/streamreadbytesuntil[Stream.readByteUntil()]
+#LINGUAGEM# link:../../stream/streamreadbytesuntil[Stream.readBytesUntil()]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
readByteUntil -> readBytesUntil

Fixes https://github.com/arduino/reference-pt/issues/239