### PR TITLE
Remove unnecessary "See Also" link

### DIFF
--- a/Language/Variables/Data Types/boolean.adoc
+++ b/Language/Variables/Data Types/boolean.adoc
@@ -67,7 +67,6 @@ void loop()
 
 [role="language"]
 #LINGUAGEM# link:../../../variables/constants/constants[constantes] +
-#LINGUAGEM# link:../../../variables/data-types/bool/[bool]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
"See Also" links for all pages in the same section are automatically added so this link only makes the reference more difficult to maintain.

Fixes https://github.com/arduino/reference-pt/issues/242