### PR TITLE
Document String variable in Parameters section of String functions

### DIFF
--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -26,7 +26,7 @@ string.c_str()
 
 [float]
 === Parâmetros
-Nenhum
+`minhaString`: uma variável do tipo String
 
 [float]
 === Retorna

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -26,6 +26,8 @@ string.concat(param)
 
 [float]
 === Parâmetros
+`minhaString`: uma variável do tipo String
+
 `param`: *Tipos de dados permitidos* String, string, char, byte, int, unsigned int, long, unsigned long, float, double, e a __FlashStringHelper(macro F()).
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -28,6 +28,8 @@ string.remove(index, count)
 
 [float]
 === Parâmetros
+`minhaString`: uma variável do tipo String
+
 `index`: índice a partir do qual remover os caracteres -int
 
 `count`: o número de caracteres a serem removidos a partir do indíce - int

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -26,6 +26,8 @@ string.reserve(tamanho)
 
 [float]
 === Parâmetros
+`minhaString`: uma variável do tipo String
+
 `tamanho`: número de bytes na memória a serem reservados para manipulação de strings - unsigned int
 
 


### PR DESCRIPTION
Some of the reference pages were missing this from the Parameters section.

Fixes https://github.com/arduino/reference-pt/issues/243