### PR TITLE
Correct misleading/confusing titles of if reference page

### DIFF
--- a/Language/Structure/Control Structure/if.adoc
+++ b/Language/Structure/Control Structure/if.adoc
@@ -1,10 +1,10 @@
 ---
-title: if...else
+title: if
 categories: [ "Structure" ]
 subCategories: [ "Estruturas de Controle" ]
 ---
 
-= if e ==, !=, <, > (operador condicional e operadores de comparação)
+= if
 
 
 // OVERVIEW SECTION STARTS


### PR DESCRIPTION
Previously, the "entity title" of the page was "if...else", but this page makes no mention of else. There is a separate page that documents else. The page title "if (conditional) and ==, !=, <, > (comparison operators)" is also unnecessarily confusing. There are separate reference pages for the comparison operators.

Fixes https://github.com/arduino/reference-pt/issues/280