### PR TITLE
Open external See also links in new window/tab

### DIFF
--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -101,6 +101,6 @@ Se o pino de entrada analógica não estiver conectado a nada, o valor retornado
 
 [role="language"]
 * #LINGUAGEM# link:../../zero-due-mkr-family/analogreadresolution[analogReadResolution()]
-* #LINGUAGEM# https://www.arduino.cc/en/Tutorial/AnalogInputPins[Tutorial: Pinos de entrada analógica (Em Inglês)]
+* #LINGUAGEM# https://www.arduino.cc/en/Tutorial/AnalogInputPins[Tutorial: Pinos de entrada analógica (Em Inglês)^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -86,7 +86,7 @@ Alternativamente, você pode conectar a tensão de referência externa ao pino A
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada (Em Inglês)]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -61,7 +61,7 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent Tutorial (Em Inglês)] +
+#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent Tutorial (Em Inglês)^] +
 
 [role="language"]
 #LINGUAGEM# link:../begin[begin()] +

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -90,7 +90,7 @@ Os pinos de entrada analógica podem ser também usados como pinos digitais, ref
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Tutorial: Pinos digitais (Em Inglês)]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Tutorial: Pinos digitais (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/delay.adoc
+++ b/Language/Functions/Time/delay.adoc
@@ -86,7 +86,7 @@ No entanto, certas coisas continuam a acontecer enquanto a função delay() est�
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/BlinkWithoutDelay[Blink Sem Delay (Em Inglês)]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/BlinkWithoutDelay[Blink Sem Delay (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -82,7 +82,7 @@ Note que o valor retornado por `millis()` é unsigned long, erros podem ser gera
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/BlinkWithoutDelay[Blink Sem Delay (Em Inglês)]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/BlinkWithoutDelay[Blink Sem Delay (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/USB/Keyboard.adoc
+++ b/Language/Functions/USB/Keyboard.adoc
@@ -63,11 +63,11 @@ link:../keyboard/keyboardwrite[Keyboard.write()]
 Exemplos abaixo em Inglês.
 
 [role="example"]
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl[KeyboardAndMouseControl]: Demonstra os comandos das bibliotecas Mouse e Keyboard em um programa. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardMessage[KeyboardMessage]: Envia uma string de texto quando um botão é pressionado. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardLogout[KeyboardLogout]: Desloga o usuário atual com uma combinação de teclas. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardSerial[KeyboardSerial]: Lê um byte da porta serial e o retorna como uma tecla pressionada. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardReprogram[KeyboardReprogram]: Abre uma nova janela na IDE Arduino e reprograma a placa com um simples programa blink. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl[KeyboardAndMouseControl^]: Demonstra os comandos das bibliotecas Mouse e Keyboard em um programa. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardMessage[KeyboardMessage^]: Envia uma string de texto quando um botão é pressionado. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardLogout[KeyboardLogout^]: Desloga o usuário atual com uma combinação de teclas. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardSerial[KeyboardSerial^]: Lê um byte da porta serial e o retorna como uma tecla pressionada. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardReprogram[KeyboardReprogram^]: Abre uma nova janela na IDE Arduino e reprograma a placa com um simples programa blink. +
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/USB/Mouse.adoc
+++ b/Language/Functions/USB/Mouse.adoc
@@ -60,9 +60,9 @@ link:../mouse/mouseispressed[Mouse.isPressed()]
 Exemplos abaixo em Inglês.
 
 [role="example"]
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl[KeyboardAndMouseControl]: Demonstra os comandos das bibliotecas Mouse e Keyboard em um programa. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/ButtonMouseControl[ButtonMouseControl]: Controla o movimento do cursor com 5 pushbuttons. +
-#EXEMPLO# http://www.arduino.cc/en/Tutorial/JoystickMouseControl[JoystickMouseControl]: Controla o movimento do cursor com um Joystick quando um botão é pressionado. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl[KeyboardAndMouseControl^]: Demonstra os comandos das bibliotecas Mouse e Keyboard em um programa. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/ButtonMouseControl[ButtonMouseControl^]: Controla o movimento do cursor com 5 pushbuttons. +
+#EXEMPLO# http://www.arduino.cc/en/Tutorial/JoystickMouseControl[JoystickMouseControl^]: Controla o movimento do cursor com um Joystick quando um botão é pressionado. +
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Zero, Due, MKR Family/analogReadResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogReadResolution.adoc
@@ -104,7 +104,7 @@ Usar uma resolução de 16 bits (ou qualquer resolução *mais alta* que as capa
 === Ver Também
 
 [role="example"]
-#EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada(Em Inglês)] +
+#EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada(Em Inglês)^] +
 
 [role="language"]
 #LINGUAGEM# link:../../analog-io/analogread[analogRead()]

--- a/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
@@ -136,7 +136,7 @@ Se você configurar `analogWriteResolution()` com um valor menor que a capacidad
 #LINGUAGEM# link:../../math/map[map()]
 
 [role="example"]
-#EXAMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada(Em Inglês)]
+#EXAMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada(Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -45,6 +45,6 @@ Um ponteiro para a versão em estilo C do objeto String.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -48,6 +48,6 @@ O caractere na posição n da String.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -52,6 +52,6 @@ Compara duas Strings, testando se uma vem antes da outra na tabela ASCII, ou se 
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -49,6 +49,6 @@ Adiciona o parâmetro ao final da String.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -50,6 +50,6 @@ Testa se uma String termina ou não com os caracteres de outra String.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -47,6 +47,6 @@ Verifica se duas Strings são iguais. A comparação é case-sensitive (letras m
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -47,6 +47,6 @@ Verifica se duas strings são iguais. A comparação, nesse caso, não é case-s
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -50,6 +50,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -51,6 +51,6 @@ A posição da minhaString especificada dentro do objeto String, ou -1 se não f
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -51,6 +51,6 @@ A posição da string especificada dentro do objeto String, ou -1 se não for en
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -43,6 +43,6 @@ O comprimento da String em caracteres.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -51,6 +51,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -50,6 +50,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -78,7 +78,7 @@ void loop() {
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -50,6 +50,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -47,6 +47,6 @@ Testa se uma String começa ou não com os caracteres de uma outra String.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -53,6 +53,6 @@ A substring.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -50,6 +50,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -48,6 +48,6 @@ Se não foi possível realizar uma conversão válida, porque a String não come
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -48,6 +48,6 @@ Se não foi possível realizar uma conversão válida, porque a String não come
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -46,6 +46,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -45,6 +45,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -46,6 +46,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -52,6 +52,6 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -51,6 +51,6 @@ minhaString1 == minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -50,6 +50,6 @@ Uma String que é a combinação das duas Strings originais.
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -53,6 +53,6 @@ minhaString1 != minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -54,6 +54,6 @@ O carctere na posição n da String. O mesmo que charAt().
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -53,6 +53,6 @@ minhaString1 > minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -53,6 +53,6 @@ minhaString1 >= minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -53,6 +53,6 @@ minhaString1 < minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -54,6 +54,6 @@ minhaString1 <= minhaString2
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^] +
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -140,7 +140,7 @@ String stringOne =  String(5.698, 3);                  // usando um float e o n�
 #LINGUAGEM# link:../string/operators/differentfrom[!= (diferente de)] +
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais sobre objetos String (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais sobre objetos String (Em Inglês)^] +
 
 
 // SEE ALSO SECTION STARTS

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -209,7 +209,7 @@ Serial.print(F("Esse texto foi guardado na memória flash do Arduino"));
 === Ver Também
 
 [role="example"]
-#EXEMPLO# https://www.arduino.cc/playground/Learning/Memory[Tipos de memória de uma placa Arduino (Em Inglês)] +
+#EXEMPLO# https://www.arduino.cc/playground/Learning/Memory[Tipos de memória de uma placa Arduino (Em Inglês)^] +
 
 [role="definition"]
 #DEFINIÇÃO# link:../../data-types/array[array] +


### PR DESCRIPTION
According to the reference example:
```
// Please note that all external links need to be opened in a new window/tab by adding ^ right before the last square brackets
* #DEFINITION# http://arduino.cc/en/Tutorial/PWM[PWM^]
```

Fixes https://github.com/arduino/reference-pt/issues/281