### PR TITLE
Add note to reference example pages about the need to make reference page links lower case

### DIFF
--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Parent_Of_Entities.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Parent_Of_Entities.adoc
@@ -87,6 +87,7 @@ http://arduino.cc[serialEvent()]
 // Whenever you want to link to another Reference term, or more in general to a relative link,
 // use the syntax shown below. Please note that the file format is subsituted by  attribute.
 // Please note that you always need to replace spaces that you might find in folder/file names with %20
+// The entire link to Reference pages must be lower case, regardless of the case of the folders and files in this repository.
 * #LANGUAGE# link:../AsciiDoc_Template-Single_Entity[Single Entity]
 * #LANGUAGE# link:../../AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary[AsciiDoc Template Dictionary]
 

--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
@@ -117,7 +117,8 @@ image::http://arduino.cc/en/uploads/Main/ArduinoUno_R3_Front_450px.jpg[caption="
 // Whenever you want to link to another Reference term, or more in general to a relative link,
 // use the syntax shown below. Please note that the file format is subsituted by  attribute.
 // Please note that you always need to replace spaces that you might find in folder/file names with %20
-// for language tag, items will be automatically generated for any other item of the same subcategory, 
+// The entire link to Reference pages must be lower case, regardless of the case of the folders and files in this repository.
+// For language tag, items will be automatically generated for any other item of the same subcategory, 
 // no need to add links to other pages of the same subcategory
 // if you don't include this section, a minimal version with only the other pages of the same subcategory will be generated.
 * #LANGUAGE# link:../AsciiDoc_Template-Parent_Of_Entities[Parent Of Entities]


### PR DESCRIPTION
This is a common mistake that is very easy to make.

Fixes https://github.com/arduino/reference-pt/issues/292