### PR TITLE
Use consistent formatting of all code

### DIFF
--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
@@ -76,13 +76,11 @@ int ledPin = 9;      // LED connected to digital pin 9
 int analogPin = 3;   // potentiometer connected to analog pin 3
 int val = 0;         // variable to store the read value
 
-void setup()
-{
+void setup() {
   pinMode(ledPin, OUTPUT);   // sets the pin as output
 }
 
-void loop()
-{
+void loop() {
   val = analogRead(analogPin);   // read the input pin
   analogWrite(ledPin, val / 4);  // analogRead values go from 0 to 1023, analogWrite values from 0 to 255
 }

--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -52,16 +52,14 @@ O exemplo abaixo calcula a duração de um pulso no pino 7.
 
 [source,arduino]
 ----
-int pino = 7;              //pino para a entrada do pulso
-unsigned long duration;   //variável para guardar a duração do pulso
+int pino = 7;           //pino para a entrada do pulso
+unsigned long duration; //variável para guardar a duração do pulso
 
-void setup()
-{
-  pinMode(pino, INPUT);    // pino 7 como entrada
+void setup() {
+  pinMode(pino, INPUT); // pino 7 como entrada
 }
 
-void loop()
-{
+void loop() {
   duration = pulseIn(pino, HIGH); //mede a duração de um pulso HIGH no pino 7
 }
 ----

--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -67,19 +67,17 @@ O código abaixo lê o valor de um pino de entrada analógica e mostra seu valor
 
 [source,arduino]
 ----
-int analogPin = A3;     // terminal do meio de um potênciometro conectado ao pino analógico 3
-                       // terminais mais externos são conectados um no ground e o outro em +5V
-int val = 0;           // variável para guardar o valor lido
+int analogPin = A3; // terminal do meio de um potênciometro conectado ao pino analógico 3
+                    // terminais mais externos são conectados um no ground e o outro em +5V
+int val = 0;        // variável para guardar o valor lido
 
-void setup()
-{
-  Serial.begin(9600);              //  configura a porta serial
+void setup() {
+  Serial.begin(9600);           // configura a porta serial
 }
 
-void loop()
-{
-  val = analogRead(analogPin);     // lê o pino de entrada
-  Serial.println(val);             // imprime o valor na porta serial
+void loop() {
+  val = analogRead(analogPin);  // lê o pino de entrada
+  Serial.println(val);          // imprime o valor na porta serial
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -58,19 +58,17 @@ Controla a saída para um LED proporcionalmente a um valor lido de um potenciôm
 
 [source,arduino]
 ----
-int ledPin = 9;      // LED conectado ao pino digital 9
-int analogPin = 3;   // potenciômetro conectado ao pino analógico 3
-int val = 0;         // variável para guradar o valor lido
+int ledPin = 9;     // LED conectado ao pino digital 9
+int analogPin = 3;  // potenciômetro conectado ao pino analógico 3
+int val = 0;        // variável para guradar o valor lido
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);   // configura  o pino como saída
+void setup() {
+  pinMode(ledPin, OUTPUT);  // configura  o pino como saída
 }
 
-void loop()
-{
-  val = analogRead(analogPin);   // lê o pino de entrada analógica
-  analogWrite(ledPin, val / 4);  // analogRead retorna valores de 0 a 1023, analogWrite recebe de 0 a 255
+void loop() {
+  val = analogRead(analogPin);  // lê o pino de entrada analógica
+  analogWrite(ledPin, val / 4); // analogRead retorna valores de 0 a 1023, analogWrite recebe de 0 a 255
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Characters/isAlpha.adoc
+++ b/Language/Functions/Characters/isAlpha.adoc
@@ -50,15 +50,12 @@ isAlpha(thisChar)
 O código a seguir testa se uma variável chamada this é uma letra.
 [source,arduino]
 ----
-if (isAlpha(this))      // testa se a variável this é uma letra
-{
-	Serial.println("The character is alpha");
+if (isAlpha(this)) {  // testa se a variável this é uma letra
+  Serial.println("The character is alpha");
 }
-else
-{
-	Serial.println("The character is not alpha");
+else {
+  Serial.println("The character is not alpha");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -50,15 +50,12 @@ isAlphaNumeric(thisChar)
 
 [source,arduino]
 ----
-if (isAlphaNumeric(this))      // testa se this é uma letra ou um número
-{
-	Serial.println("The character is alphanumeric");
+if (isAlphaNumeric(this)) { // testa se this é uma letra ou um número
+  Serial.println("The character is alphanumeric");
 }
-else
-{
-	Serial.println("The character is not alphanumeric");
+else {
+  Serial.println("The character is not alphanumeric");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isAscii.adoc
+++ b/Language/Functions/Characters/isAscii.adoc
@@ -50,15 +50,12 @@ isAscii(thisChar)
 
 [source,arduino]
 ----
-if (isAscii(this))      // testa se this é  um caractere Ascii
-{
-	Serial.println("The character is Ascii");
+if (isAscii(this)) {  // testa se this é  um caractere Ascii
+  Serial.println("The character is Ascii");
 }
-else
-{
-	Serial.println("The character is not Ascii");
+else {
+  Serial.println("The character is not Ascii");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isControl.adoc
+++ b/Language/Functions/Characters/isControl.adoc
@@ -50,15 +50,12 @@ isControl(thisChar)
 
 [source,arduino]
 ----
-if (isControl(this))      // testa se a variável this é um caractere de controle
-{
-	Serial.println("The character is a control character");
+if (isControl(this)) {  // testa se a variável this é um caractere de controle
+  Serial.println("The character is a control character");
 }
-else
-{
-	Serial.println("The character is not a control character");
+else {
+  Serial.println("The character is not a control character");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isDigit.adoc
+++ b/Language/Functions/Characters/isDigit.adoc
@@ -50,15 +50,12 @@ isDigit(thisChar)
 
 [source,arduino]
 ----
-if (isDigit(this))      // testa se this é um digito
-{
-	Serial.println("The character is a number");
+if (isDigit(this)) {  // testa se this é um digito
+  Serial.println("The character is a number");
 }
-else
-{
-	Serial.println("The character is not a number");
+else {
+  Serial.println("The character is not a number");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isGraph.adoc
+++ b/Language/Functions/Characters/isGraph.adoc
@@ -50,15 +50,12 @@ isGraph(thisChar)
 
 [source,arduino]
 ----
-if (isGraph(this))      // testa se this é um caractere imprimível mas não um espaço.
-{
-	Serial.println("The character is printable");
+if (isGraph(this)) {  // testa se this é um caractere imprimível mas não um espaço.
+  Serial.println("The character is printable");
 }
-else
-{
-	Serial.println("The character is not printable");
+else {
+  Serial.println("The character is not printable");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isHexadecimalDigit.adoc
+++ b/Language/Functions/Characters/isHexadecimalDigit.adoc
@@ -50,15 +50,12 @@ isHexadecimalDigit(thisChar)
 
 [source,arduino]
 ----
-if (isHexadecimalDigit(this))      // testa se this é um digito hexadecimal
-{
-	Serial.println("The character is an hexadecimal digit");
+if (isHexadecimalDigit(this)) { // testa se this é um digito hexadecimal
+  Serial.println("The character is an hexadecimal digit");
 }
-else
-{
-	Serial.println("The character is not an hexadecimal digit");
+else {
+  Serial.println("The character is not an hexadecimal digit");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isLowerCase.adoc
+++ b/Language/Functions/Characters/isLowerCase.adoc
@@ -50,15 +50,12 @@ isLowerCase(thisChar)
 
 [source,arduino]
 ----
-if (isLowerCase(this))      // testa se this é uma letra minúscula
-{
-	Serial.println("The character is lower case");
+if (isLowerCase(this)) {  // testa se this é uma letra minúscula
+  Serial.println("The character is lower case");
 }
-else
-{
-	Serial.println("The character is not lower case");
+else {
+  Serial.println("The character is not lower case");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isPrintable.adoc
+++ b/Language/Functions/Characters/isPrintable.adoc
@@ -50,15 +50,12 @@ isPrintable(thisChar)
 
 [source,arduino]
 ----
-if (isPrintable(this))      // testa se this é imprimível
-{
-	Serial.println("The character is printable");
+if (isPrintable(this)) {  // testa se this é imprimível
+  Serial.println("The character is printable");
 }
-else
-{
-	Serial.println("The character is not printable");
+else {
+  Serial.println("The character is not printable");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isPunct.adoc
+++ b/Language/Functions/Characters/isPunct.adoc
@@ -50,15 +50,12 @@ isPunct(thisChar)
 
 [source,arduino]
 ----
-if (isPunct(this))      // testa se this é um caractere de pontuação
-{
-	Serial.println("The character is a punctuation");
+if (isPunct(this)) {  // testa se this é um caractere de pontuação
+  Serial.println("The character is a punctuation");
 }
-else
-{
-	Serial.println("The character is not a punctuation");
+else {
+  Serial.println("The character is not a punctuation");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -50,15 +50,12 @@ isSpace(thisChar)
 
 [source,arduino]
 ----
-if (isSpace(this))      // testa se this é o caractere de espaço
-{
-	Serial.println("The character is a space");
+if (isSpace(this)) {  // testa se this é o caractere de espaço
+  Serial.println("The character is a space");
 }
-else
-{
-	Serial.println("The character is not a space");
+else {
+  Serial.println("The character is not a space");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isUpperCase.adoc
+++ b/Language/Functions/Characters/isUpperCase.adoc
@@ -50,13 +50,11 @@ isUpperCase(thisChar)
 
 [source,arduino]
 ----
-if (isUpperCase(this))      // testa se this é uma letra maiúscula
-{
-	Serial.println("The character is upper case");
+if (isUpperCase(this)) {  // testa se this é uma letra maiúscula
+  Serial.println("The character is upper case");
 }
-else
-{
-	Serial.println("The character is not upper case");
+else {
+  Serial.println("The character is not upper case");
 }
 
 ----

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -51,15 +51,12 @@ isWhitespace(thisChar)
 
 [source,arduino]
 ----
-if (isWhitespace(this))      // testa se this é um caractere de espaço em branco
-{
-	Serial.println("The character is a white space");
+if (isWhitespace(this)) { // testa se this é um caractere de espaço em branco
+  Serial.println("The character is a white space");
 }
-else
-{
-	Serial.println("The character is not a white space");
+else {
+  Serial.println("The character is not a white space");
 }
-
 ----
 
 --

--- a/Language/Functions/Communication/Serial/available.adoc
+++ b/Language/Functions/Communication/Serial/available.adoc
@@ -49,23 +49,23 @@ O código abaixo devolve um caractere recebido na porta serial.
 
 [source,arduino]
 ----
-int incomingByte = 0;	// para  dados recebidos na porta serial
+int incomingByte = 0; // para  dados recebidos na porta serial
 
 void setup() {
-	Serial.begin(9600);	// abre a porta serial, taxa de transmissão 9600 bps
+  Serial.begin(9600); // abre a porta serial, taxa de transmissão 9600 bps
 }
 
 void loop() {
 
-	// enviar resposta apenas quando receber dados:
-	if (Serial.available() > 0) {
-		// lê o dado recebido:
-		incomingByte = Serial.read();
+  // enviar resposta apenas quando receber dados:
+  if (Serial.available() > 0) {
+    // lê o dado recebido:
+    incomingByte = Serial.read();
 
-		// responder o que foi recebido:
-		Serial.print("Eu recebi: ");
-		Serial.println(incomingByte, DEC);
-	}
+    // responder o que foi recebido:
+    Serial.print("Eu recebi: ");
+    Serial.println(incomingByte, DEC);
+  }
 }
 ----
 [%hardbreaks]
@@ -78,7 +78,6 @@ O código abaixo transfere os dados de uma porta serial do Arduino Mega para out
 void setup() {
   Serial.begin(9600);
   Serial1.begin(9600);
-
 }
 
 void loop() {
@@ -86,7 +85,6 @@ void loop() {
   if (Serial.available()) {
     int inByte = Serial.read();
     Serial1.print(inByte, DEC);
-
   }
   // Lê da porta 1, envia para porta 0:
   if (Serial1.available()) {

--- a/Language/Functions/Communication/Serial/begin.adoc
+++ b/Language/Functions/Communication/Serial/begin.adoc
@@ -100,7 +100,7 @@ O código abaixo inicia todas as portas seriais no Arduino Mega com diferentes t
 // (Serial, Serial1, Serial2, Serial3),
 // com baud rates diferentes:
 
-void setup(){
+void setup() {
   Serial.begin(9600);
   Serial1.begin(38400);
   Serial2.begin(19200);

--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -65,7 +65,7 @@ void setup() {
 }
 
 void loop() {
- //porcede normalmente
+  //porcede normalmente
 }
 ----
 

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -65,18 +65,18 @@ O código abaixo imprime um valor na porta serial em vários formatos.
 [source,arduino]
 ----
 /*
-Usa um loop for para dados e imprime cada número em vários formatos.
+  Usa um loop for para dados e imprime cada número em vários formatos.
 */
-int x = 0;    // variable
+int x = 0;  // variable
 
 void setup() {
-  Serial.begin(9600);      // abre a porta serial a 9600 bps:
+  Serial.begin(9600); // abre a porta serial a 9600 bps:
 }
 
 void loop() {
   // imprime rótulos para cada base
-  Serial.print("NUMERO");       // imprime um rótulo
-  Serial.print("\t");              // imprime uma tabulação (TAB)
+  Serial.print("NUMERO"); // imprime um rótulo
+  Serial.print("\t"); // imprime uma tabulação (TAB)
 
   Serial.print("DEC");
   Serial.print("\t");
@@ -90,7 +90,7 @@ void loop() {
   Serial.print("BIN");
   Serial.println("\t");
 
-  for(x=0; x< 64; x++){    // apenas uma parte da tabela ASCII, edite para mais ou menos valores
+  for (x = 0; x < 64; x++) {  // apenas uma parte da tabela ASCII, edite para mais ou menos valores
 
     // imprime cada número em vários formatos:
     Serial.print(x);       // imprime como decimal codificado em ASCII- o mesmo que "DEC"
@@ -105,9 +105,9 @@ void loop() {
     Serial.print(x, OCT);  // imprime como octal codificado em ASCII
     Serial.print("\t");    // imprime uma tabulação
 
-    Serial.println(x, BIN); // imprime como binário codificado em ASCII
-                            //então adiciona o retorno (enter) com "println"
-    
+    Serial.println(x, BIN);// imprime como binário codificado em ASCII
+    //então adiciona o retorno (enter) com "println"
+
     delay(200);             // delay de 200 milissegundos
   }
   Serial.println();         // imprime outro retorno

--- a/Language/Functions/Communication/Serial/read.adoc
+++ b/Language/Functions/Communication/Serial/read.adoc
@@ -47,23 +47,22 @@ O código abaixo devolve um dado recebido na porta serial.
 
 [source,arduino]
 ----
-int incomingByte = 0;   // variável para o dado recebido
+int incomingByte = 0; // variável para o dado recebido
 
 void setup() {
-        Serial.begin(9600);     // abre a porta serial, configura a taxa de transferência para 9600 bps
+  Serial.begin(9600); // abre a porta serial, configura a taxa de transferência para 9600 bps
 }
 
 void loop() {
+  // apenas responde quando dados são recebidos:
+  if (Serial.available() > 0) {
+    // lê do buffer o dado recebido:
+    incomingByte = Serial.read();
 
-        // apenas responde quando dados são recebidos:
-        if (Serial.available() > 0) {
-                // lê do buffer o dado recebido:
-                incomingByte = Serial.read();
-
-                // responde com o dado recebido:
-                Serial.print("I received: ");
-                Serial.println(incomingByte, DEC);
-        }
+    // responde com o dado recebido:
+    Serial.print("I received: ");
+    Serial.println(incomingByte, DEC);
+  }
 }
 ----
 

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -21,23 +21,23 @@ Nota: Atualmente, `serialEvent()` não é compativel com o Esplora, Leonardo, ou
 
 [source,arduino]
 ----
-void serialEvent(){
-//código
+void serialEvent() {
+  //código
 }
 ----
 Apenas Arduino Mega:
 [source,arduino]
 ----
-void serialEvent1(){
-//código
+void serialEvent1() {
+  //código
 }
 
-void serialEvent2(){
-//código
+void serialEvent2() {
+  //código
 }
 
-void serialEvent3(){
-//código
+void serialEvent3() {
+  //código
 }
 ----
 

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -58,14 +58,14 @@ O código abaixo usa a função Serial.write() para escrever um valor e uma stri
 
 [source,arduino]
 ----
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
 
-void loop(){
+void loop() {
   Serial.write(45); // envia um byte com valor 45 (0b101101)
 
-   int bytesSent = Serial.write(“hello”); //envia a string “hello” e retorna o tamanho da string.
+  int bytesSent = Serial.write(“hello”);  //envia a string “hello” e retorna o tamanho da string.
 }
 ----
 

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -50,20 +50,18 @@ Aciona o pino 13 para o mesmo valor que o pino 7, declarado como entrada.
 
 [source,arduino]
 ----
-int ledPin = 13;   // LED conectado ao pino digital 13
-int inPin = 7;     // botão conectado ao pino digital 7
-int val = 0;       // variável para guardar o valor lido
+int ledPin = 13;  // LED conectado ao pino digital 13
+int inPin = 7;    // botão conectado ao pino digital 7
+int val = 0;      // variável para guardar o valor lido
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);      // configura o pino digital 13 como saída
-  pinMode(inPin, INPUT);        // configura o pino digital 7 como entrada
+void setup() {
+  pinMode(ledPin, OUTPUT);    // configura o pino digital 13 como saída
+  pinMode(inPin, INPUT);      // configura o pino digital 7 como entrada
 }
 
-void loop()
-{
-  val = digitalRead(inPin);     // lê o pino de entrada
-  digitalWrite(ledPin, val);    // aciona o LED com o valor lido do botão
+void loop() {
+  val = digitalRead(inPin);   // lê o pino de entrada
+  digitalWrite(ledPin, val);  // aciona o LED com o valor lido do botão
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -60,17 +60,15 @@ The código configura o pino digital 13 como `OUTPUT` e troca seu estado entre `
 
 [source,arduino]
 ----
-void setup()
-{
-  pinMode(13, OUTPUT);          // configura o pino digital 13 como saída
+void setup() {
+  pinMode(13, OUTPUT);    // configura o pino digital 13 como saída
 }
 
-void loop()
-{
-  digitalWrite(13, HIGH);       // ativa o pino digital 13
-  delay(1000);                  // espera por um segundo
-  digitalWrite(13, LOW);        // desativa o pino digital 13
-  delay(1000);                  // espera por um segundo
+void loop() {
+  digitalWrite(13, HIGH); // ativa o pino digital 13
+  delay(1000);            // espera por um segundo
+  digitalWrite(13, LOW);  // desativa o pino digital 13
+  delay(1000);            // espera por um segundo
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -55,17 +55,15 @@ The código configura o pino digital 13 como `OUTPUT` e troca seu estado entre `
 
 [source,arduino]
 ----
-void setup()
-{
-  pinMode(13, OUTPUT);          // configura o pino digital 13 como saída
+void setup() {
+  pinMode(13, OUTPUT);    // configura o pino digital 13 como saída
 }
 
-void loop()
-{
-  digitalWrite(13, HIGH);       // ativa o pino digital 13
-  delay(1000);                  // espera por um segundo
-  digitalWrite(13, LOW);        // desativa o pino digital 13
-  delay(1000);                  // espera por um segundo
+void loop() {
+  digitalWrite(13, HIGH); // ativa o pino digital 13
+  delay(1000);            // espera por um segundo
+  digitalWrite(13, LOW);  // desativa o pino digital 13
+  delay(1000);            // espera por um segundo
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Interrupts/interrupts.adoc
+++ b/Language/Functions/Interrupts/interrupts.adoc
@@ -46,8 +46,7 @@ O código abaixo mostra como desativar e reativar interrupções.
 ----
 void setup() {}
 
-void loop()
-{
+void loop() {
   noInterrupts();
   // código crítico e sensível ao tempo aqui
   interrupts();

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -44,8 +44,7 @@ O código abaixo mostra como desativar e reativar interrupções.
 ----
 void setup() {}
 
-void loop()
-{
+void loop() {
   noInterrupts();
   // código crítico e sensível ao tempo aqui
   interrupts();

--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -46,10 +46,10 @@ Calcula o módulo (ou valor absoluto) de um número.
 Por causa da forma em que a função `abs()` é implementada, evite usar outras funções dentro dos parênteses, isso pode levar a resultados incorretos.
 [source,arduino]
 ----
-abs(a++);   // evitar isso - causa resultados incorretos
+abs(a++); // evitar isso - causa resultados incorretos
 
-abs(a);     // Ao invés disso, usar esta forma
-a++;        // manter a aritmética fora da função
+abs(a);   // Ao invés disso, usar esta forma
+a++;      // manter a aritmética fora da função
 ----
 [%hardbreaks]
 

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -55,7 +55,7 @@ O código limita os valores de uma variável com a leitura de um sensor entre 10
 
 [source,arduino]
 ----
-sensVal = constrain(sensVal, 10, 150);    // limita os valores entre 10 e 150
+sensVal = constrain(sensVal, 10, 150);  // limita os valores entre 10 e 150
 ----
 
 --

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -71,8 +71,7 @@ O valor mapeado para o novo intervalo.
 /* Mapeia um valor analógico para 8 bits (0 a 255) */
 void setup() {}
 
-void loop()
-{
+void loop() {
   int val = analogRead(0);
   val = map(val, 0, 1023, 0, 255);
   analogWrite(9, val);
@@ -87,8 +86,7 @@ Para os matematicamnete interessados, aqui tem-se o código da função:
 
 [source,arduino]
 ----
-long map(long x, long in_min, long in_max, long out_min, long out_max)
-{
+long map(long x, long in_min, long in_max, long out_min, long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 ----

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -49,7 +49,7 @@ O código garante que o valor de sensVal seja pelo menos 20.
 [source,arduino]
 ----
 sensVal = max(sensVal, 20); // atribui a sensVal o maior valor, seja sensVal ou 20
-                           // (efetivamente garantindo que sensVal seja ao menos 20)
+                            // (efetivamente garantindo que sensVal seja ao menos 20)
 ----
 [%hardbreaks]
 
@@ -60,10 +60,10 @@ Talvez contraintuitivamente, `max()` é constantemente usada para restringir o e
 Por causa da forma em que a função `max()` é implementada, evite usar outras funções dentro dos parênteses, isso pode levar a resultados incorretos.
 [source,arduino]
 ----
-max(a--, 0);   // evitar isso - causa resultados incorretos
+max(a--, 0);  // evitar isso - causa resultados incorretos
 
-max(a, 0);     // ao invés disso, usar esta forma
-a--;           // manter a aritmética fora da função
+max(a, 0);    // ao invés disso, usar esta forma
+a--;          // manter a aritmética fora da função
 ----
 
 --

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -49,8 +49,8 @@ O código garante que o valor de sensVal nunca é maior que 100.
 
 [source,arduino]
 ----
-sensVal = min(sensVal, 100); // atribui a sensVal o menor valor, seja sensVal ou 100
-                             // garantindo que esse nunca seja maior que 100.
+sensVal = min(sensVal, 100);  // atribui a sensVal o menor valor, seja sensVal ou 100
+                              // garantindo que esse nunca seja maior que 100.
 ----
 [%hardbreaks]
 
@@ -61,10 +61,10 @@ Talvez contraintuitivamente, `max()` é constantemente usada para restringir o e
 Por causa da forma em que a função `max()` é implementada, evite usar outras funções dentro dos parênteses, isso pode levar a resultados incorretos.
 [source,arduino]
 ----
-min(a++, 100);   // evitar isso - causa resultados incorretos
+min(a++, 100);  // evitar isso - causa resultados incorretos
 
-min(a, 100);     // ao invés disso, usar esta forma
-a++;             // manter a aritmética fora da função
+min(a, 100);    // ao invés disso, usar esta forma
+a++;            // manter a aritmética fora da função
 ----
 
 --

--- a/Language/Functions/Random Numbers/random.adoc
+++ b/Language/Functions/Random Numbers/random.adoc
@@ -53,7 +53,7 @@ O código abaixo gera números aleatórios e os imprime na porta serial.
 ----
 long randNumber;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 
   // Se o pino de entrada analógica 0 é deixado desconectado,

--- a/Language/Functions/Random Numbers/randomSeed.adoc
+++ b/Language/Functions/Random Numbers/randomSeed.adoc
@@ -46,23 +46,22 @@ O código abaixo imprime números aleatórios na porta serial.
 ----
 long randNumber;
 
-void setup(){
+void setup() {
   // inicializa a porta serial.
   Serial.begin(9600);
-  
+
   // inicializa o gerador de números aleatórios.
   // um pino analógico desconectado irá retornar um
   // valor aleatório de tensão em analogRead()
   randomSeed(analogRead(0));
 }
 
-void loop(){
+void loop() {
   // calcula o próximo número aleatório entre 0 e 299
   randNumber = random(300);
-  
+
   // imprime o valor na porta serial
   Serial.println(randNumber);
-
   delay(50);
 }
 ----

--- a/Language/Functions/Time/delay.adoc
+++ b/Language/Functions/Time/delay.adoc
@@ -51,19 +51,17 @@ O código pausa o programa por um segundo antes de trocar o estado do pino 13.
 
 [source,arduino]
 ----
-int ledPin = 13;                 // LED conectado ao pino digital 13
+int ledPin = 13;              // LED conectado ao pino digital 13
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);      // configura o pino digital como saída
+void setup() {
+  pinMode(ledPin, OUTPUT);    // configura o pino digital como saída
 }
 
-void loop()
-{
-  digitalWrite(ledPin, HIGH);   // acende o LED
-  delay(1000);                  // espera por um segundo
-  digitalWrite(ledPin, LOW);    // apaga o LED
-  delay(1000);                  // espera por um segundo
+void loop() {
+  digitalWrite(ledPin, HIGH); // acende o LED
+  delay(1000);                // espera por um segundo
+  digitalWrite(ledPin, LOW);  // apaga o LED
+  delay(1000);                // espera por um segundo
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -53,19 +53,17 @@ O código abaixo configura o pino 8 para funcionar como pino de saída. Ele ent�
 
 [source,arduino]
 ----
-int outPin = 8;                 // pino digital 8
+int outPin = 8;               // pino digital 8
 
-void setup()
-{
-  pinMode(outPin, OUTPUT);      // configura o pino digital como saída
+void setup() {
+  pinMode(outPin, OUTPUT);    // configura o pino digital como saída
 }
 
-void loop()
-{
-  digitalWrite(outPin, HIGH);   // ativa o pino
-  delayMicroseconds(50);        // pausa por 50 microssegundos
-  digitalWrite(outPin, LOW);    // desativa o pino
-  delayMicroseconds(50);        // pausa por 50 microssegundos
+void loop() {
+  digitalWrite(outPin, HIGH); // ativa o pino
+  delayMicroseconds(50);      // pausa por 50 microssegundos
+  digitalWrite(outPin, LOW);  // desativa o pino
+  delayMicroseconds(50);      // pausa por 50 microssegundos
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -52,15 +52,16 @@ O código abaixo imprime o número de microssegundos passados desde que a placa 
 ----
 unsigned long time;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
-void loop(){
+void loop() {
   Serial.print("Time: ");
   time = micros();
 
-  Serial.println(time);  // imprime o tempo desde que o programa iniciou
-  delay(1000);           // espera um segundo, para não enviar quantidades massivas de dados
+  Serial.println(time); // imprime o tempo desde que o programa iniciou
+  delay(1000);          // espera um segundo, para não enviar quantidades massivas de dados
+}
 ----
 [%hardbreaks]
 

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -53,15 +53,15 @@ O código lê o tempo em milissegundos desde que a placa Arduino foi ligada.
 ----
 unsigned long time;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
-void loop(){
+void loop() {
   Serial.print("Time: ");
   time = millis();
 
-  Serial.println(time);    // imprime o tempo desde que o programa iniciou
-  delay(1000);             // espera um segundo, para não enviar quantidades massivas de dados
+  Serial.println(time); // imprime o tempo desde que o programa iniciou
+  delay(1000);          // espera um segundo, para não enviar quantidades massivas de dados
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -58,7 +58,7 @@ void setup() {
 
 void loop() {
   //se o botão for pressionado
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     //envia a mensagem
     Keyboard.print("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardEnd.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardEnd.adoc
@@ -56,7 +56,7 @@ void setup() {
 }
 
 void loop() {
- //não faz nada aqui
+  //não faz nada aqui
 }
 ----
 

--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -61,7 +61,7 @@ void setup() {
 
 void loop() {
   // se o botão for pressionado
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     // envia a mensagem
     Keyboard.print("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -63,7 +63,7 @@ void setup() {
 
 void loop() {
   // se o botão for pressionado
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     // envia a mensagem, automaticamnete seguida de \n e \r
     Keyboard.println("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardWrite.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardWrite.adoc
@@ -69,7 +69,7 @@ void setup() {
 
 void loop() {
   // se o botão for pressionado
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     // envia o caratere ASCII 'A',
     Keyboard.write(65);
   }

--- a/Language/Functions/USB/Mouse/mouseBegin.adoc
+++ b/Language/Functions/USB/Mouse/mouseBegin.adoc
@@ -44,17 +44,16 @@ Nada
 ----
 #include <Mouse.h>
 
-void setup(){
- pinMode(2, INPUT);
+void setup() {
+  pinMode(2, INPUT);
 }
 
-void loop(){
+void loop() {
 
   // inicia a biblioteca Mouse qaundo o botão é pressionado
-  if(digitalRead(2) == HIGH){
-     Mouse.begin();
-   }
-
+  if (digitalRead(2) == HIGH) {
+    Mouse.begin();
+  }
 }
 ----
 

--- a/Language/Functions/USB/Mouse/mouseClick.adoc
+++ b/Language/Functions/USB/Mouse/mouseClick.adoc
@@ -19,8 +19,8 @@ Envia um clique momentâneo para o computador, na localização atual do cursor.
 
 [float]
 === Sintaxe
-`Mouse.click();` +
-`Mouse.click(botão);`
+`Mouse.click()` +
+`Mouse.click(botão)`
 
 
 [float]
@@ -56,15 +56,15 @@ Nada
 ----
 #include <Mouse.h>
 
-void setup(){
-  pinMode(2,INPUT);
+void setup() {
+  pinMode(2, INPUT);
   // inicializa a biblioteca mouse
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //se o botão for pressionado, envia um clique com o botão esquerdo do mouse
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.click();
   }
 }

--- a/Language/Functions/USB/Mouse/mouseEnd.adoc
+++ b/Language/Functions/USB/Mouse/mouseEnd.adoc
@@ -47,21 +47,20 @@ Nada
 ----
 #include <Mouse.h>
 
-void setup(){
-  pinMode(2,INPUT);
+void setup() {
+  pinMode(2, INPUT);
   // inicializa a biblioteca Mouse
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   // se o botão for pressionado, envia um clique com o botão esquerdo do mouse
   // e depois encerra a emulação do mouse
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.click();
     Mouse.end();
   }
 }
-
 ----
 
 --

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -57,35 +57,35 @@ Se o botão do mouse passado para a função está pressionado ou não - `bool`
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   // o botão que inicia o clique do mouse
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   // o botão que termina o clique do mouse
-  pinMode(3,INPUT);
-  
+  pinMode(3, INPUT);
+
   // inicia a comunicação serial com o computador
   Serial.begin(9600);
-  
+
   // inicia a biblioteca Mouse
   Mouse.begin();
 }
 
-void loop(){
-  //  variável para checar o esatdo do botão do mouse
-  int mouseState=0;
-  
-  //se o botão conectado ao pino 2 for pressionado, aperta e segura o botão do mouse virtual e salva o estado do mesmo na variável
-  if(digitalRead(2) == HIGH){
+void loop() {
+  // variável para checar o esatdo do botão do mouse
+  int mouseState = 0;
+
+  // se o botão conectado ao pino 2 for pressionado, aperta e segura o botão do mouse virtual e salva o estado do mesmo na variável
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
-    mouseState=Mouse.isPressed();
+    mouseState = Mouse.isPressed();
   }
-  
-  //se o botão conectado ao pino 3 for pressionado, libera o botão do mouse virtual e salva o estado do mesmo na variável
-  if(digitalRead(3) == HIGH){
+
+  // se o botão conectado ao pino 3 for pressionado, libera o botão do mouse virtual e salva o estado do mesmo na variável
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
-    mouseState=Mouse.isPressed();
+    mouseState = Mouse.isPressed();
   }
-  
+
   // imprime o estado atual do botão do mouse emulado
   Serial.println(mouseState);
   delay(10);

--- a/Language/Functions/USB/Mouse/mouseMove.adoc
+++ b/Language/Functions/USB/Mouse/mouseMove.adoc
@@ -52,28 +52,30 @@ Nada
 // Código originalmente em Inglês
 // Traduzido em Dezembro de 2017
 
-const int xAxis = A1;         // sensor analógico para o eixo x
-const int yAxis = A2;         // sensor analógico para o eixo y
+const int xAxis = A1;       // sensor analógico para o eixo x
+const int yAxis = A2;       // sensor analógico para o eixo y
 
-int range = 12;               // intervalo se sada do movimento em X ou Y
-int responseDelay = 2;        // atraso de resposta do mouse, em ms
-int threshold = range/4;      // limiar de descanso
-int center = range/2;         // valor da poisção de descanso
+int range = 12;             // intervalo se sada do movimento em X ou Y
+int responseDelay = 2;      // atraso de resposta do mouse, em ms
+int threshold = range / 4;  // limiar de descanso
+int center = range / 2;     // valor da poisção de descanso
 int minima[] = {
-  1023, 1023};                // minima real de analogRead para {x, y}
+  1023, 1023
+};  // minima real de analogRead para {x, y}
 int maxima[] = {
-  0,0};                       // maxima real de analogRead para {x, y}
+  0, 0
+};  // maxima real de analogRead para {x, y}
 int axis[] = {
-  xAxis, yAxis};              // número dos pinos para {x, y}
-int mouseReading[2];          // leituras finais do mouse para {x, y}
+  xAxis, yAxis
+};  // número dos pinos para {x, y}
+int mouseReading[2];  // leituras finais do mouse para {x, y}
 
 
 void setup() {
- Mouse.begin();
+  Mouse.begin();
 }
 
 void loop() {
-
   // lê e escala os dois eixos:
   int xReading = readAxis(0);
   int yReading = readAxis(1);
@@ -84,12 +86,12 @@ void loop() {
 }
 
 /*
-  Lê um eixo (0 ou 1 para x ou y) e escala o intervalo 
+  Lê um eixo (0 ou 1 para x ou y) e escala o intervalo
   da entrada analógica para um intervalo entre 0 e <range>
 */
 
 int readAxis(int axisNumber) {
-  int distance = 0;    // distância ao centro do intervalo de saída
+  int distance = 0; // distância ao centro do intervalo de saída
 
   // lê a entrada nalógica:
   int reading = analogRead(axis[axisNumber]);
@@ -106,12 +108,12 @@ int readAxis(int axisNumber) {
   // mapeia o intervalo da leitura da entrada analógica para o intervalo de saída:
   reading = map(reading, minima[axisNumber], maxima[axisNumber], 0, range);
 
- // se o valor se saída está fora do limiar de descanso, usa-o:
+  // se o valor se saída está fora do limiar de descanso, usa-o:
   if (abs(reading - center) > threshold) {
     distance = (reading - center);
   }
 
-  // O eixo y precisa ser invertido para 
+  // O eixo y precisa ser invertido para
   // mapear o movimento corretamente:
   if (axisNumber == 1) {
     distance = -distance;

--- a/Language/Functions/USB/Mouse/mousePress.adoc
+++ b/Language/Functions/USB/Mouse/mousePress.adoc
@@ -21,7 +21,7 @@ Antes de usar `Mouse.press()`, você precisa iniciar a comunicação com link:..
 
 [float]
 === Sintaxe
-`Mouse.press();` +
+`Mouse.press()` +
 `Mouse.press(botão)`
 
 
@@ -60,22 +60,22 @@ Nada
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   // o botão que inicia o apertar do botão do mouse
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   // o botão que libera do botão do mouse
-  pinMode(3,INPUT);
+  pinMode(3, INPUT);
   // inicia a biblioteca Mouse
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   // se o botão conectado ao pino 2 for pressionado, aperta e segura o botão do mouse virtual
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
   }
   // se o botão conectado ao pino 2 for pressionado, solta o botão do mouse virtual
-  if(digitalRead(3) == HIGH){
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
   }
 }

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -54,22 +54,22 @@ Nada
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   // o botão que inicia o apertar do botão do mouse
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   // o botão que libera do botão do mouse
-  pinMode(3,INPUT);
+  pinMode(3, INPUT);
   // inicia a biblioteca Mouse
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   // se o botão conectado ao pino 2 for pressionado, aperta e segura o botão do mouse virtual
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
   }
   // se o botão conectado ao pino 2 for pressionado, solta o botão do mouse virtual
-  if(digitalRead(3) == HIGH){
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
   }
 }

--- a/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
@@ -72,7 +72,7 @@ O código configura a resolução da saída PWM para diferentes valores.
 
 [source,arduino]
 ----
-void setup(){
+void setup() {
   // inicia a porta serial
   Serial.begin(9600);
   // configura os pinos digitais 11 a 13 como saída
@@ -81,7 +81,7 @@ void setup(){
   pinMode(13, OUTPUT);
 }
 
-void loop(){
+void loop() {
   // Lê o valor analógico em A0 e mapeia-o para
   // um pino PWM com um LED conectado
   int sensorVal = analogRead(A0);
@@ -90,9 +90,9 @@ void loop(){
 
   // a resolução PWM padrão
   analogWriteResolution(8);
-  analogWrite(11, map(sensorVal, 0, 1023, 0 ,255));
+  analogWrite(11, map(sensorVal, 0, 1023, 0, 255));
   Serial.print(" , 8-bit PWM value : ");
-  Serial.print(map(sensorVal, 0, 1023, 0 ,255));
+  Serial.print(map(sensorVal, 0, 1023, 0, 255));
 
   // Muda a reolução PWM para 12 bits
   // A resolução completa de 12 bits é suportada

--- a/Language/Structure/Arithmetic Operators/addition.adoc
+++ b/Language/Structure/Arithmetic Operators/addition.adoc
@@ -45,8 +45,10 @@ soma = operando1 + operando2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a + b; // A variável 'c' recebe o valor 15 depois que essa operação é executada
+int a = 5;
+int b = 10;
+int c = 0;
+c = a + b;  // A variável 'c' recebe o valor 15 depois que essa operação é executada
 ----
 [%hardbreaks]
 
@@ -60,9 +62,10 @@ c = a + b; // A variável 'c' recebe o valor 15 depois que essa operação é ex
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a + b; // a variável 'c' guarda o valor 12 apenas, em vez de 12.1 
+c = a + b;  // a variável 'c' guarda o valor 12 apenas, em vez de 12.1 
 ----
 [%hardbreaks]
 --

--- a/Language/Structure/Arithmetic Operators/division.adoc
+++ b/Language/Structure/Arithmetic Operators/division.adoc
@@ -44,8 +44,10 @@ resultado = numerador / denominador;
 
 [source,arduino]
 ----
-int a = 50, b = 10, c = 0;
-c = a / b; // A variável 'c' recebe o valor 5 depois que essa operação é executada
+int a = 50;
+int b = 10;
+int c = 0;
+c = a / b;  // A variável 'c' recebe o valor 5 depois que essa operação é executada
 ----
 [%hardbreaks]
 
@@ -57,9 +59,10 @@ c = a / b; // A variável 'c' recebe o valor 5 depois que essa operação é exe
 
 [source,arduino]
 ----
-float a = 55.5, b = 6.6;
+float a = 55.5;
+float b = 6.6;
 int c = 0;
-c = a / b; // a variável 'c' armazena o valor 8 em vez do resultado esperado 8.409
+c = a / b;  // a variável 'c' armazena o valor 8 em vez do resultado esperado 8.409
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Arithmetic Operators/multiplication.adoc
+++ b/Language/Structure/Arithmetic Operators/multiplication.adoc
@@ -45,8 +45,10 @@ produto = operando1 * operando2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a * b; // A variável 'c' recebe o valor 50 depois que essa operação é executada
+int a = 5;
+int b = 10;
+int c = 0;
+c = a * b;  // A variável 'c' recebe o valor 50 depois que essa operação é executada
 ----
 [%hardbreaks]
 
@@ -60,9 +62,10 @@ c = a * b; // A variável 'c' recebe o valor 50 depois que essa operação é ex
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a * b; // a variável 'c' armazena o valor 36 em vez do resultado esperado 36.3
+c = a * b;  // a variável 'c' armazena o valor 36 em vez do resultado esperado 36.3
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Arithmetic Operators/subtraction.adoc
+++ b/Language/Structure/Arithmetic Operators/subtraction.adoc
@@ -45,8 +45,10 @@ diferença = operando1 - operando2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a - b; // A variável 'c' recebe o valor -5 depois que essa operação é executada
+int a = 5;
+int b = 10;
+int c = 0;
+c = a - b;  // A variável 'c' recebe o valor -5 depois que essa operação é executada
 ----
 [%hardbreaks]
 
@@ -60,9 +62,10 @@ c = a - b; // A variável 'c' recebe o valor -5 depois que essa operação é ex
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a - b; // a variável 'c' armazena o valor -1 em vez do resultado esperado -1.1
+c = a - b;  // a variável 'c' armazena o valor -1 em vez do resultado esperado -1.1
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
@@ -44,8 +44,8 @@ variável << numero_de_bits;
 
 [source,arduino]
 ----
-int a = 5;        // binário: 0000000000000101
-int b = a << 3;   // binário: 0000000000101000, ou 40 em decimal
+int a = 5;      // binário: 0000000000000101
+int b = a << 3; // binário: 0000000000101000, ou 40 em decimal
 ----
 [%hardbreaks]
 
@@ -55,7 +55,7 @@ Quando você desloca um valor x por y bits (x << y), os y bits mais a esquerda e
 
 [source,arduino]
 ----
-int x = 5;        // binário: 0000000000000101
+int x = 5;  // binário: 0000000000000101
 int y = 14;
 int resultado = x << y;  // binário: 0100000000000000 - os primeiros 1 em 101 foram descartados
 ----
@@ -86,10 +86,10 @@ void printOut1(int c) {
   for (int bits = 7; bits > -1; bits--) {
     // Compara bits 7-0 no byte
     if (c & (1 << bits)) {
-      Serial.print ("1");
+      Serial.print("1");
     }
     else {
-      Serial.print ("0");
+      Serial.print("0");
     }
   }
 }

--- a/Language/Structure/Bitwise Operators/bitshiftRight.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftRight.adoc
@@ -43,8 +43,8 @@ variável`: *Tipos de dados permitidos:* byte, int, long +
 
 [source,arduino]
 ----
-int a = 40;       // binário: 0000000000101000
-int b = a >> 3;   // binário: 0000000000000101, ou 5 em decimal
+int a = 40;     // binário: 0000000000101000
+int b = a >> 3; // binário: 0000000000000101, ou 5 em decimal
 ----
 [%hardbreaks]
 
@@ -54,7 +54,7 @@ Quando você desloca x à direita por y bits (x >> y), e o bit mais significativ
 
 [source,arduino]
 ----
-int x = -16;     // binário: 1111111111110000
+int x = -16;  // binário: 1111111111110000
 int y = 3;
 int resultado = x >> y;  // binário: 1111111111111110
 ----
@@ -62,7 +62,7 @@ Esse comportamento, chamdo extensão do sinal, é frequentemente indesejável. E
 
 [source,arduino]
 ----
-int x = -16;                   // binário: 1111111111110000
+int x = -16;  // binário: 1111111111110000
 int y = 3;
 int resultado = (unsigned int)x >> y;  // binário: 0001111111111110
 ----
@@ -71,7 +71,7 @@ Se você for cuidadoso para evitar a extensão do sinal, você pode usar o opera
 [source,arduino]
 ----
 int x = 1000;
-int y = x >> 3;   // divisão inteira de 1000 por 8, resultando em y = 125.
+int y = x >> 3; // divisão inteira de 1000 por 8, resultando em y = 125.
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseNot.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseNot.adoc
@@ -36,8 +36,8 @@ Em outras palavras:
 
 [source,arduino]
 ----
-int a = 103;    // binário:  0000000001100111
-int b = ~a;     // binário:  1111111110011000 = -104
+int a = 103;  // binário:  0000000001100111
+int b = ~a;   // binário:  1111111110011000 = -104
 ----
 [%hardbreaks]
 
@@ -45,7 +45,7 @@ int b = ~a;     // binário:  1111111110011000 = -104
 === Notas e Advertências
 Você pode ficar surpreso ao ver um número negativo como -104 como o resultado dessa operação. Isso acontece porque o bit mais significativo de um valor `int` é o chamado bit de sinal. Se esse bit é 1, o número é interpretado como negativo. Essa codificação de números positivos e negativos é referido como complemento de dois. Para mais informações, veja o arquivo da Wikipédia a respeito do https://pt.wikipedia.org/wiki/Complemento_para_dois[complemento de dois^].
 
-Um comentário adicional: é interessante notar que para qualquer inteiro x, ~x é o mesmo que -x-1.
+Um comentário adicional: é interessante notar que para qualquer inteiro x, ~x é o mesmo que -x - 1.
 
 As vezes, o bit de sinal em uma expressão pode causar alguns efeitos indesejados, veja a página do operador de deslocamento à direita (>>), por exemplo, para mais detalhes.
 [%hardbreaks]

--- a/Language/Structure/Bitwise Operators/bitwiseXor.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseXor.adoc
@@ -51,14 +51,14 @@ O operador ^ é frequentemente utilizado para trocar (isto é, mudar de 0 para 1
 ----
 // Blink_Pin_5
 // Demo do XOR
-void setup(){
-    DDRD = DDRD | B00100000; // configura o pino digital 5 como saída
-    Serial.begin(9600);
+void setup() {
+  DDRD = DDRD | B00100000;  // configura o pino digital 5 como saída
+  Serial.begin(9600);
 }
 
-void loop(){
-    PORTD = PORTD ^ B00100000;  // inverte bit 5 (pino 5), e deixa os outros intocados
-    delay(100);
+void loop() {
+  PORTD = PORTD ^ B00100000;  // inverte bit 5 (pino 5), e deixa os outros intocados
+  delay(100);
 }
 ----
 

--- a/Language/Structure/Boolean Operators/logicalAnd.adoc
+++ b/Language/Structure/Boolean Operators/logicalAnd.adoc
@@ -32,8 +32,8 @@ Esse operador pode ser usado dentro da condição de um laço link:../../control
 
 [source,arduino]
 ----
-if (digitalRead(2) == HIGH  && digitalRead(3) == HIGH) { // se AMBOS os botões estão em HIGH
-    // código a ser executado caso as duas condições sejam verdadeiras
+if (digitalRead(2) == HIGH  && digitalRead(3) == HIGH) {  // se AMBOS os botões estão em HIGH
+  // código a ser executado caso as duas condições sejam verdadeiras
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Boolean Operators/logicalNot.adoc
+++ b/Language/Structure/Boolean Operators/logicalNot.adoc
@@ -40,7 +40,7 @@ if (!x) { // se x não é true
 Pode ser usado para inverter o valor booleano.
 [source,arduino]
 ----
-x = !y;   // o valor booleano invertido de y é guardado em x
+x = !y; // o valor booleano invertido de y é guardado em x
 ----
 
 

--- a/Language/Structure/Comparison Operators/equalTo.adoc
+++ b/Language/Structure/Comparison Operators/equalTo.adoc
@@ -23,7 +23,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x == y;   // é verdadeiro se x é igual a y e é falso se x não é igual a y
+x == y; // é verdadeiro se x é igual a y e é falso se x não é igual a y
 ----
 
 [float]
@@ -45,8 +45,7 @@ x == y;   // é verdadeiro se x é igual a y e é falso se x não é igual a y
 
 [source,arduino]
 ----
-if (x==y)      // testa se x é igual a y
-{
+if (x == y) { // testa se x é igual a y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Comparison Operators/greaterThan.adoc
+++ b/Language/Structure/Comparison Operators/greaterThan.adoc
@@ -21,7 +21,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x > y;   // é verdadeiro se x é maior que y e é falso se x é igual ou menor que y
+x > y;  // é verdadeiro se x é maior que y e é falso se x é igual ou menor que y
 ----
 
 [float]
@@ -42,8 +42,7 @@ x > y;   // é verdadeiro se x é maior que y e é falso se x é igual ou menor 
 
 [source,arduino]
 ----
-if (x>y)      // testa se x é maior que y
-{
+if (x > y) {  // testa se x é maior que y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
@@ -22,7 +22,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x >= y;   // é verdadeiro se x é maior ou igual a y e é falso se x é menor que y
+x >= y; // é verdadeiro se x é maior ou igual a y e é falso se x é menor que y
 ----
 
 [float]
@@ -44,8 +44,7 @@ x >= y;   // é verdadeiro se x é maior ou igual a y e é falso se x é menor q
 
 [source,arduino]
 ----
-if (x>=y)      // testa se x é maior que ou igual a y
-{
+if (x >= y) {  // testa se x é maior que ou igual a y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Comparison Operators/lessThan.adoc
+++ b/Language/Structure/Comparison Operators/lessThan.adoc
@@ -23,7 +23,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x < y;   // é verdadeiro se x é menor que y e é falso se x é igual ou maior que y
+x < y;  // é verdadeiro se x é menor que y e é falso se x é igual ou maior que y
 ----
 
 [float]
@@ -44,8 +44,7 @@ x < y;   // é verdadeiro se x é menor que y e é falso se x é igual ou maior 
 
 [source,arduino]
 ----
-if (x<y)      // testa se x é menor que y
-{
+if (x < y) {  // testa se x é menor que y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
@@ -23,7 +23,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x <= y;   // é verdadeiro se x é menor ou igual a y e é falso se x é maior que y
+x <= y; // é verdadeiro se x é menor ou igual a y e é falso se x é maior que y
 ----
 
 [float]
@@ -45,8 +45,7 @@ x <= y;   // é verdadeiro se x é menor ou igual a y e é falso se x é maior q
 
 [source,arduino]
 ----
-if (x<=y)      // testa se x é menor que ou igual a y
-{
+if (x <= y) { // testa se x é menor que ou igual a y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Comparison Operators/notEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/notEqualTo.adoc
@@ -23,7 +23,7 @@ Compara a variável à esquerda com o valor ou variável à direita do operador.
 === Sintaxe
 [source,arduino]
 ----
-x != y;   // é falso se x é igual a y e é verdadeiro se x não é igual a y
+x != y; // é falso se x é igual a y e é verdadeiro se x não é igual a y
 ----
 
 [float]
@@ -45,8 +45,7 @@ x != y;   // é falso se x é igual a y e é verdadeiro se x não é igual a y
 
 [source,arduino]
 ----
-if (x!=y)      // testa se x é diferente de y
-{
+if (x != y) { // testa se x é diferente de y
   // faz algo apenas se o resultado da comparação é verdadeiro
 }
 ----

--- a/Language/Structure/Compound Operators/compoundAddition.adoc
+++ b/Language/Structure/Compound Operators/compoundAddition.adoc
@@ -22,7 +22,7 @@ Essa é uma abreviação conveniente para realizar a adição de uma variável c
 === Sintaxe
 [source,arduino]
 ----
-x += y;   // equivalente a expressão x = x + y;
+x += y; // equivalente a expressão x = x + y;
 ----
 
 [float]
@@ -45,7 +45,7 @@ x += y;   // equivalente a expressão x = x + y;
 [source,arduino]
 ----
 x = 2;
-x += 4;      // x agora contém 6
+x += 4; // x agora contém 6
 ----
 
 --

--- a/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
@@ -29,7 +29,7 @@ Uma revisão do operator bitwise E `&`:
 === Sintaxe
 [source,arduino]
 ----
-x &= y;   // equivalente a x = x & y;
+x &= y; // equivalente a x = x & y;
 ----
 
 [float]
@@ -92,8 +92,8 @@ Então:
 
 [source,arduino]
 ----
-myByte =  B10101010;
-myByte &= B11111100; // resulta em B10101000
+myByte = B10101010;
+myByte &= B11111100;  // resulta em B10101000
 ----
 
 [%hardbreaks]

--- a/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
@@ -29,7 +29,7 @@ Uma revisão do operador bitwise OU `|`:
 === Sintaxe
 [source,arduino]
 ----
-x |= y;   // equivalente a x = x | y;
+x |= y; // equivalente a x = x | y;
 ----
 
 [float]
@@ -90,7 +90,7 @@ Abaixo a mesma representação com os bits da variável substituidos pelo símbo
 Então:
 [source,arduino]
 ----
-meuByte =  B10101010;
+meuByte = B10101010;
 meuByte |= B00000011; // igual a B10101011;
 ----
 

--- a/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
@@ -29,7 +29,7 @@ Uma revisão do operador bitwise OU EXCLUSIVO `^`:
 === Sintaxe
 [source,arduino]
 ----
-x ^= y;   // equivalente a x = x ^ y;
+x ^= y; // equivalente a x = x ^ y;
 ----
 
 [float]
@@ -89,7 +89,7 @@ Abaixo a mesma representação com os bits da variável substituidos pelo símbo
 Então:
 [source,arduino]
 ----
-myByte =  B10101010;
+myByte = B10101010;
 myByte ^= B00000011 == B10101001;
 ----
 

--- a/Language/Structure/Compound Operators/compoundDivision.adoc
+++ b/Language/Structure/Compound Operators/compoundDivision.adoc
@@ -22,7 +22,7 @@ Essa é uma abreviação conveniente para realizar a divisão de uma variável c
 === Sintaxe
 [source,arduino]
 ----
-x /= y;   // equivalente a expressão x = x / y;
+x /= y; // equivalente a expressão x = x / y;
 ----
 
 [float]
@@ -45,7 +45,7 @@ x /= y;   // equivalente a expressão x = x / y;
 [source,arduino]
 ----
 x = 2;
-x /= 2;      // x agora contém 1
+x /= 2; // x agora contém 1
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Compound Operators/compoundMultiplication.adoc
+++ b/Language/Structure/Compound Operators/compoundMultiplication.adoc
@@ -21,7 +21,7 @@ Essa é uma abreviação conveniente para realizar a multiplicação de uma vari
 === Sintaxe
 [source,arduino]
 ----
-x *= y;   // equivalente a expressão x = x * y;
+x *= y; // equivalente a expressão x = x * y;
 ----
 
 [float]
@@ -44,7 +44,7 @@ x *= y;   // equivalente a expressão x = x * y;
 [source,arduino]
 ----
 x = 2;
-x *= 2;      // x agora contém 4
+x *= 2; // x agora contém 4
 ----
 
 --

--- a/Language/Structure/Compound Operators/compoundSubtraction.adoc
+++ b/Language/Structure/Compound Operators/compoundSubtraction.adoc
@@ -22,7 +22,7 @@ Essa é uma abreviação conveniente para realizar a subtração de uma variáve
 === Sintaxe
 [source,arduino]
 ----
-x -= y;   // equivalente a expressão x = x - y;
+x -= y; // equivalente a expressão x = x - y;
 ----
 
 [float]
@@ -45,7 +45,7 @@ x -= y;   // equivalente a expressão x = x - y;
 [source,arduino]
 ----
 x = 20;
-x -= 2;      // x agora contém 18
+x -= 2; // x agora contém 18
 ----
 
 

--- a/Language/Structure/Compound Operators/decrement.adoc
+++ b/Language/Structure/Compound Operators/decrement.adoc
@@ -21,8 +21,8 @@ Decrementa o valor de uma variável em 1.
 === Sintaxe
 [source,arduino]
 ----
-x-- ;   // decrementa x em um e retorna o valor antigo de x
---x ;   // decrementa x em um e retorna o novo valor de x
+x--;  // decrementa x em um e retorna o valor antigo de x
+--x;  // decrementa x em um e retorna o novo valor de x
 ----
 
 [float]
@@ -46,8 +46,8 @@ O valor original ou decrementado da variável, que depende se o operador está �
 [source,arduino]
 ----
 x = 2;
-y = --x;      // x agora contém 1, y contém 1
-y = x--;      // x contém 0, mas y ainda contém 1
+y = --x;  // x agora contém 1, y contém 1
+y = x--;  // x contém 0, mas y ainda contém 1
 ----
 
 --

--- a/Language/Structure/Compound Operators/increment.adoc
+++ b/Language/Structure/Compound Operators/increment.adoc
@@ -45,8 +45,8 @@ O valor original ou incrementado da variável, que depende se o operador está �
 [source,arduino]
 ----
 x = 2;
-y = ++x;      // x agora contém 3, y contém 3
-y = x++;      // x contém 4, mas y ainda contém 3
+y = ++x;  // x agora contém 3, y contém 3
+y = x++;  // x contém 4, mas y ainda contém 3
 ----
 
 --

--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -28,15 +28,14 @@ No códgo seguinte, o break quebra o loop `for` quando o valor do sensor excede 
 [source,arduino]
 ----
 int lim = 40;
-for (x = 0; x < 255; x ++)
-{
-    analogWrite(PWMpin, x);
-    sens = analogRead(sensorPin);
-    if (sens > lim){      // "foge" do o loop `for`
-       x = 0;
-       break;
-    }
-    delay(50);
+for (x = 0; x < 255; x ++) {
+  analogWrite(PWMpin, x);
+  sens = analogRead(sensorPin);
+  if (sens > lim) { // "foge" do o loop `for`
+    x = 0;
+    break;
+  }
+  delay(50);
 }
 ----
 

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -31,14 +31,13 @@ O comando `continue` "pula" o resto da iteração atual de um loop (link:../for[
 O código abaixo escreve o valor de 0 a 255 ao pino `PWMpin`, mas pula os valores no intervalo 41 a 119.
 [source,arduino]
 ----
-for (x = 0; x <= 255; x ++)
-{
-    if (x > 40 && x < 120){      // cria um salto nos valores
-        continue;
-    }
+for (x = 0; x <= 255; x ++) {
+  if (x > 40 && x < 120) {  // cria um salto nos valores
+    continue;
+  }
 
-    analogWrite(PWMpin, x);
-    delay(50);
+  analogWrite(PWMpin, x);
+  delay(50);
 }
 ----
 

--- a/Language/Structure/Control Structure/doWhile.adoc
+++ b/Language/Structure/Control Structure/doWhile.adoc
@@ -20,9 +20,8 @@ O loop `do...while` funciona da mesma forma que o loop link:../while[while], com
 === Sintaxe
 [source,arduino]
 ----
-do
-{
-    // bloco de comandos
+do {
+  // bloco de comandos
 } while (condição);
 ----
 A `condição` é uma expressão booleana que é avaliada como verdadeiro ou falso, respectivamente `true` ou `false` na linguagem Arduino.
@@ -43,11 +42,9 @@ A `condição` é uma expressão booleana que é avaliada como verdadeiro ou fal
 [source,arduino]
 ----
 int x = 0;
-do
-{
+do {
   delay(50);          // espera os sensores estabilizarem
   x = readSensors();  // checa os sensores
-
 } while (x < 100);
 ----
 

--- a/Language/Structure/Control Structure/else.adoc
+++ b/Language/Structure/Control Structure/else.adoc
@@ -24,16 +24,13 @@ Note que um bloco `else if` pode ser usado sem um bloco `else` no final e vice-v
 === Sintaxe
 [source,arduino]
 ----
-if (condição1)
-{
+if (condição1) {
   // faz coisa A
 }
-else if (condição2)
-{
+else if (condição2) {
   // faz coisa B
 }
-else
-{
+else {
   // faz coisa C
 }
 ----
@@ -50,16 +47,13 @@ else
 Abaixo um trecho de código de um sistema de controle de temperatura
 [source,arduino]
 ----
-if (temperatura >= 70)
-{
+if (temperatura >= 70) {
   //Perigo! Desligar o sistema
 }
-else if (temperatura >= 60 && temperatura < 70)
-{
+else if (temperatura >= 60 && temperatura < 70) {
   //Cuidado! Requerida a atenção do usuário
 }
-else
-{
+else {
   //Seguro! Continue as tarefas usuais...
 }
 ----

--- a/Language/Structure/Control Structure/for.adoc
+++ b/Language/Structure/Control Structure/for.adoc
@@ -21,7 +21,7 @@ O comando `for` [e usado para repetir um bloco de código envolvido por chaves. 
 [source,arduino]
 ----
 for (inicialização; condição; incremento) {
-	//comando(s);
+  //comando(s);
 }
 ----
 
@@ -45,17 +45,15 @@ A *inicialização* ocorre primeiro e apenas uma vez. A cada repetição do loop
 // Varia o brilho de um LED usando um pino PWM
 int pinoPWM = 10; // LED em série com um resistor de 470 ohm no pino 10
 
-void setup()
-{
+void setup() {
   // setup não necessário
 }
 
-void loop()
-{
-   for (int i=0; i <= 255; i++){
-      analogWrite(pinoPWM, i);
-      delay(10);
-   }
+void loop() {
+  for (int i = 0; i <= 255; i++) {
+    analogWrite(pinoPWM, i);
+    delay(10);
+  }
 }
 ----
 [%hardbreaks]
@@ -69,7 +67,7 @@ Por exemplo, usar uma multiplicação no comando de incremento irá gerar uma pr
 
 [source,arduino]
 ----
-for(int x = 2; x < 100; x = x * 1.5){
+for (int x = 2; x < 100; x = x * 1.5) {
   println(x);
 }
 ----
@@ -81,14 +79,15 @@ Outro exemplo, Aplica um efeito de _fading_ crescente e decrescente em um LED co
 
 [source,arduino]
 ----
-void loop()
-{
-   int x = 1;
-   for (int i = 0; i > -1; i = i + x){
-      analogWrite(pinoPWM, i);
-      if (i == 255) x = -1;             // muda a direção no pico
-      delay(10);
-   }
+void loop() {
+  int x = 1;
+  for (int i = 0; i > -1; i = i + x) {
+    analogWrite(pinoPWM, i);
+    if (i == 255) {
+      x = -1; // muda a direção no pico
+    }
+    delay(10);
+  }
 }
 ----
 

--- a/Language/Structure/Control Structure/goto.adoc
+++ b/Language/Structure/Control Structure/goto.adoc
@@ -39,13 +39,15 @@ goto rótulo; // envia o fluxo do programa de volta para o rótulo
 O código abaixo "foge" de dentro de todos os laços caso a leitura no pino analógico 0 seja maior que 250. 
 [source,arduino]
 ----
-for(byte r = 0; r < 255; r++){
-    for(byte g = 255; g > 0; g--){
-        for(byte b = 0; b < 255; b++){
-            if (analogRead(0) > 250){ goto cancelar;}
-            // mais comandos ...
-        }
+for (byte r = 0; r < 255; r++) {
+  for (byte g = 255; g > 0; g--) {
+    for (byte b = 0; b < 255; b++) {
+      if (analogRead(0) > 250) {
+        goto cancelar;
+      }
+      // mais comandos ...
     }
+  }
 }
 
 cancelar:

--- a/Language/Structure/Control Structure/if.adoc
+++ b/Language/Structure/Control Structure/if.adoc
@@ -19,8 +19,7 @@ O comando `if` checa uma condição e executas o comando a seguir ou um bloco de
 === Sintaxe
 [source,arduino]
 ----
-if (condição)
-{
+if (condição) {
   //comando(s)
 }
 ----
@@ -37,17 +36,22 @@ As chaves podem ser omitidas depois de um comando `if`. Se isso é feito, a pró
 
 [source,arduino]
 ----
-if (x > 120) digitalWrite(pinoLED, HIGH);
+if (x > 120) {
+  digitalWrite(pinoLED, HIGH);
+}
 
-if (x > 120)
-digitalWrite(pinoLED, HIGH);
+if (x > 120) {
+  digitalWrite(pinoLED, HIGH);
+}
 
-if (x > 120){ digitalWrite(pinoLED, HIGH); }
+if (x > 120) {
+  digitalWrite(pinoLED, HIGH);
+}
 
-if (x > 120){
+if (x > 120) {
   digitalWrite(pinoLED1, HIGH);
   digitalWrite(pinoLED2, HIGH);
-}                                 // todas as formas acima estão corretas
+} // todas as formas acima estão corretas
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Control Structure/return.adoc
+++ b/Language/Structure/Control Structure/return.adoc
@@ -47,29 +47,26 @@ Uma função para comparar a saída de um sensor com um limiar
 
 [source,arduino]
 ----
- int checaSensor(){
-    if (analogRead(0) > 400) {
-        return 1;
-    }
-    else{
-        return 0;
-    }
+int checaSensor() {
+  if (analogRead(0) > 400) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
 }
 ----
 
-//The return keyword is handy to test a section of code without having to "comment out" large sections of possibly buggy code.
-//[source,arduino]
-//----
-//void loop(){
+The return keyword is handy to test a section of code without having to "comment out" large sections of possibly buggy code.
+[source,arduino]
+----
+void loop() {
+  return;
 
-// brilliant code idea to test here
-
-//return;
-
-// the rest of a dysfunctional sketch here
-// this code will never be executed
-//}
-//----
+  // the rest of a dysfunctional sketch here
+  // this code will never be executed
+}
+----
 [%hardbreaks]
 
 --

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -62,18 +62,18 @@ Nada
 
 [source,arduino]
 ----
-  switch (var) {
-    case 1:
-      // faz algo quando var é igual a 1
-      break;
-    case 2:
-      // faz algo quando var é igual a 1
-      break;
-    default:
-      // Se nenhum dos anteriores, faz o caso padrão default
-      // default é opcional
-      break;
-  }
+switch (var) {
+  case 1:
+    // faz algo quando var é igual a 1
+    break;
+  case 2:
+    // faz algo quando var é igual a 1
+    break;
+  default:
+    // Se nenhum dos anteriores, faz o caso padrão default
+    // default é opcional
+    break;
+}
 
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -20,7 +20,7 @@ Um loop `while` irá se repetir continuamente, e infinitamente, até a expressã
 === Sintaxe
 [source,arduino]
 ----
-while(condição){
+while (condição) {
   // código a ser executado repetidamente
 }
 ----
@@ -42,7 +42,7 @@ A `condição` é uma expressão booleana que resulta em `true` ou `false`.
 [source,arduino]
 ----
 var = 0;
-while(var < 200){
+while (var < 200) {
   // faz algo repetitivo 200 vezes
   var++;
 }

--- a/Language/Structure/Further Syntax/blockComment.adoc
+++ b/Language/Structure/Further Syntax/blockComment.adoc
@@ -46,9 +46,9 @@ O começo de um *comentário em bloco* ou *comentário de múltiplas linhas* é 
 */
 
 /*
-  if (gwb == 0){   // Comentários de única linha não permitidos dentro de um comentário em bloco 
-  x = 3;           /* Mas outro comentário de múltiplas linhas, não. Esse comentário é inválido */
-  }
+  if (gwb == 0) { // Comentários de única linha não permitidos dentro de um comentário em bloco
+  x = 3;          /* Mas outro comentário de múltiplas linhas, não. Esse comentário é inválido */
+}
 // Não esqueça o símbolo para "fechar" o comentário - deve estar balanceado!
 */
 ----

--- a/Language/Structure/Further Syntax/curlyBraces.adoc
+++ b/Language/Structure/Further Syntax/curlyBraces.adoc
@@ -43,7 +43,7 @@ Os usos principais das chaves são listados nos exemplos abaixo.
 
 [source,arduino]
 ----
-void minhafuncao(tipo argumento){
+void minhafuncao(tipo argumento) {
   comando(s)
 }
 ----
@@ -55,19 +55,16 @@ void minhafuncao(tipo argumento){
 
 [source,arduino]
 ----
-while (expressão boolena)
-{
- comando(s)
+while (expressão boolena) {
+  comando(s)
 }
 
-do
-{
- comando(s)
+do {
+  comando(s)
 } while (expressão boolena);
 
-for (inicialização; condição; incremento)
-{
- comando(s)
+for (inicialização; condição; incremento) {
+  comando(s)
 }
 ----
 [%hardbreaks]
@@ -80,18 +77,15 @@ for (inicialização; condição; incremento)
 
 [source,arduino]
 ----
-if (expressão boolena)
-{
- comandos(s)
+if (expressão boolena) {
+  comandos(s)
 }
 
-else if (expressão boolena)
-{
- comandos(s)
+else if (expressão boolena) {
+  comandos(s)
 }
-else
-{
- comandos(s)
+else {
+  comandos(s)
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -57,14 +57,14 @@ Não há ponto e vírgula após a diretiva #define. Se você incluir uma, o comp
 
 [source,arduino]
 ----
-#define pinoLED 3;    // isso é inválido
+#define pinoLED 3;  // isso é inválido
 ----
 
 Similarmente, incluir sinal de igual após #define também resultará em erros
 
 [source,arduino]
 ----
-#define pinoLED  = 3  // também é inválido
+#define pinoLED = 3  // também é inválido
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Further Syntax/singleLineComment.adoc
+++ b/Language/Structure/Further Syntax/singleLineComment.adoc
@@ -36,7 +36,7 @@ Há duas formas diferentes de se usar um comentário de uma só linha:
 int led = 13;
 
 
-digitalWrite(led, HIGH);   // acendo o LED (HIGH é o nível da tensão)
+digitalWrite(led, HIGH);  // acendo o LED (HIGH é o nível da tensão)
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Pointer Access Operators/dereference.adoc
+++ b/Language/Structure/Pointer Access Operators/dereference.adoc
@@ -30,11 +30,12 @@ Desreferência é uma das características da linguagem C para uso especificamen
 
 [source,arduino]
 ----
-int *p;          // declara um ponteiro para uma variável do tipo int
-int i = 5, resultado = 0;
-p = &i;          // agora 'p' contém o endereço de 'i'
-resultado = *p;  // 'resultado' recebe o valor contido no endereço apontado por 'p'
-                 // isto é, recebe o valor de 'i', que é 5
+int *p;         // declara um ponteiro para uma variável do tipo int
+int i = 5;
+int resultado = 0;
+p = &i;         // agora 'p' contém o endereço de 'i'
+resultado = *p; // 'resultado' recebe o valor contido no endereço apontado por 'p'
+                // isto é, recebe o valor de 'i', que é 5
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Pointer Access Operators/reference.adoc
+++ b/Language/Structure/Pointer Access Operators/reference.adoc
@@ -32,11 +32,11 @@ Referência é uma das características da linguagem C para uso especificamente 
 [source,arduino]
 ----
 
-int *p;          // declara um ponteiro para uma variável do tipo int
+int *p;         // declara um ponteiro para uma variável do tipo int
 int i = 5, resultado = 0;
-p = &i;          // agora 'p' contém o endereço de 'i'
-resultado = *p;  // 'resultado' recebe o valor contido no endereço apontado por 'p'
-                 // isto é, recebe o valor de 'i', que é 5
+p = &i;         // agora 'p' contém o endereço de 'i'
+resultado = *p; // 'resultado' recebe o valor contido no endereço apontado por 'p'
+                // isto é, recebe o valor de 'i', que é 5
 
 ----
 [%hardbreaks]

--- a/Language/Structure/Sketch/loop.adoc
+++ b/Language/Structure/Sketch/loop.adoc
@@ -31,20 +31,20 @@ Depois de criar uma função link:../setup[setup()], a qual inicializa e atribui
 int buttonPin = 3;
 
 // setup inicializa a porta serial e o pino para o botão
-void setup()
-{
+void setup() {
   Serial.begin(9600);
   pinMode(buttonPin, INPUT);
 }
 
 // loop checa o estado do botão repetidamente, e envia
 // pela serial um 'H' se este está sendo pressionado
-void loop()
-{
-  if (digitalRead(buttonPin) == HIGH)
+void loop() {
+  if (digitalRead(buttonPin) == HIGH) {
     Serial.write('H');
-  else
+  }
+  else {
     Serial.write('L');
+  }
 
   delay(1000);
 }

--- a/Language/Structure/Sketch/setup.adoc
+++ b/Language/Structure/Sketch/setup.adoc
@@ -35,16 +35,14 @@ A função `setup()` é chamada quando um sketch inicia. Use-a para inicializar 
 ----
 int buttonPin = 3;
 
-void setup()
-{
+void setup() {
   // Inicializa a porta serial
   Serial.begin(9600);
   // configura o pino 3 como INPUT
   pinMode(buttonPin, INPUT);
 }
 
-void loop()
-{
+void loop() {
   // ...
 }
 ----

--- a/Language/Variables/Constants/integerConstants.adoc
+++ b/Language/Variables/Constants/integerConstants.adoc
@@ -60,7 +60,7 @@ Essa é a matemática de senso comum a qual você já está acostumado. Constant
 === Código de Exemplo:
 [source,arduino]
 ----
-n = 101;     // o mesmo que 101 decimal   ((1 * 10^2) + (0 * 10^1) + 1)
+n = 101;  // o mesmo que 101 decimal   ((1 * 10^2) + (0 * 10^1) + 1)
 ----
 [%hardbreaks]
 
@@ -72,13 +72,13 @@ Apenas os caracteres 0 e 1 são válidos.
 === Código de Exemplo:
 [source,arduino]
 ----
-n = B101;    // o mesmo que 5 decimal   ((1 * 2^2) + (0 * 2^1) + 1)
+n = B101; // o mesmo que 5 decimal   ((1 * 2^2) + (0 * 2^1) + 1)
 ----
 
 O modificador binário funciona apenas em bytes (8 bits), ou seja, entre 0 (B0) e 255 (B11111111). Se for conveniente inserir um int (16 bits) em formato binário, você pode fazê-lo com um procedimento em dois passos, como:
 [source,arduino]
 ----
-meuInt = (B11001100 * 256) + B10101010;    // B11001100 é o byte mais significativo
+meuInt = (B11001100 * 256) + B10101010; // B11001100 é o byte mais significativo
 ----
 [%hardbreaks]
 
@@ -90,7 +90,7 @@ Apenas os caracteres 0 a 7 são válidos. Valores octais são indicados pelo pre
 === Código de Exemplo:
 [source,arduino]
 ----
-n = 0101;    // o mesmo que 65 decimal   ((1 * 8^2) + (0 * 8^1) + 1)
+n = 0101; // o mesmo que 65 decimal   ((1 * 8^2) + (0 * 8^1) + 1)
 ----
 *Cuidado:* é possível criar um bug difícil de encontrar (acidentalmente), caso seja inserido um zero antes de uma constante, fazendo com que o compilador interprete sua constante como octal.
 [%hardbreaks]
@@ -103,7 +103,7 @@ Os caracteres válidos são 0 a 9 e as letras A a F; A possui valor 10, B é 11,
 === Código de Exemplo:
 [source,arduino]
 ----
-n = 0x101;   // o qmesmo que 257 decimal   ((1 * 16^2) + (0 * 16^1) + 1)
+n = 0x101;  // o qmesmo que 257 decimal   ((1 * 16^2) + (0 * 16^1) + 1)
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -63,9 +63,8 @@ void setup() {
 }
 
 void loop() {
- // nada a ser feito aqui
+  // nada a ser feito aqui
 }
- 
 ----
 // HOW TO USE SECTION ENDS
 

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -43,9 +43,9 @@ Isso também significa que em um vetor com dez elementos, o índice nove é o ú
 
 [source,arduino]
 ----
-int meuVetor[10]={9,3,2,4,3,2,7,8,9,11};
-     // meuVetor[9]    contém 11
-     // meuVetor[10]   é inválido e contém informação aleatória (endereço de memória fora do vetor)
+int meuVetor[10] = {9, 3, 2, 4, 3, 2, 7, 8, 9, 11};
+// meuVetor[9]    contém 11
+// meuVetor[10]   é inválido e contém informação aleatória (endereço de memória fora do vetor)
 ----
 Por esse motivo, você deve ser cuidadoso ao acessar vetores. Acessar um elemento depois do final de um vetor (usar um índice maior que o tamanho declarado - 1) é ler de uma parte da memória que pode estar em uso para outros propósitos. Ler desses locais provavelmente não vai fazer mais que retornar dados inválidos. Escrever em locais aleatórios da memória é definitivamente uma má ideia e pode frequentemente levar a péssimos resultados como crashes ou mal funcionamento do programa. Isso pode também ser um bug difícil de encontrar.
 [%hardbreaks]

--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -34,22 +34,20 @@ O código abaixo mostra como usar o tipo de dado `bool`.
 int LEDpin = 5;       // LED no pino digital 5
 int switchPin = 13;   // botão conectado ao pino 13 e o outro terminal ao ground
 
-bool running = false; //variável de tipo booleano 
+bool running = false; //variável de tipo booleano
 
-void setup()
-{
+void setup() {
   pinMode(LEDpin, OUTPUT);
   pinMode(switchPin, INPUT);
-  digitalWrite(switchPin, HIGH);      // ativa o resistor pull-up
+  digitalWrite(switchPin, HIGH);    // ativa o resistor pull-up
 }
 
-void loop()
-{
-  if (digitalRead(switchPin) == LOW)
-  {  // botão foi pressionado, o pull-up mantém o pino em HIGH internamente
-    delay(100);                        // delay para fazer o debounce no botão
-    running = !running;                // troca o valor da variável running
-    digitalWrite(LEDpin, running);     // indica via LED
+void loop() {
+  if (digitalRead(switchPin) == LOW) {
+    // botão foi pressionado, o pull-up mantém o pino em HIGH internamente
+    delay(100);                     // delay para fazer o debounce no botão
+    running = !running;             // troca o valor da variável running
+    digitalWrite(LEDpin, running);  // indica via LED
   }
 }
 ----

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -35,8 +35,8 @@ O tipo de dado char é um tipo com sinal, armazenando números de -128 a 127. Pa
 
 [source,arduino]
 ----
-  char myChar = 'A';
-  char myChar = 65;      // ambas as formas são equivalentes
+char myChar = 'A';
+char myChar = 65; // ambas as formas são equivalentes
 ----
 
 

--- a/Language/Variables/Data Types/float.adoc
+++ b/Language/Variables/Data Types/float.adoc
@@ -25,7 +25,7 @@ Quando fizer cálculos com floats, você precisa adicionar um ponto decimal, do 
 
 [float]
 === Sintaxe
-`float var=val;`
+`float var=val`
 
 `var` - o nome da sua variável float
 `val` - o valor a ser dado a variável
@@ -46,16 +46,16 @@ O trecho de código demonstra algumas operações com floats.
 
 [source,arduino]
 ----
-  float myfloat;
-  float sensorCalbrate = 1.117;
+float myfloat;
+float sensorCalbrate = 1.117;
 
-  int x;
-  int y;
-  float z;
+int x;
+int y;
+float z;
 
-  x = 1;
-  y = x / 2;            // y agora contém 0, ints não podem guardar frações
-  z = (float)x / 2.0;   // z agora contém 0.5 (você deve usar 2.0, não 2)
+x = 1;
+y = x / 2;          // y agora contém 0, ints não podem guardar frações
+z = (float)x / 2.0; // z agora contém 0.5 (você deve usar 2.0, não 2)
 ----
 
 

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -46,16 +46,16 @@ Esse código cria uma variável do tipo integer chamada 'contador', a qual é in
 
 [source,arduino]
 ----
-  int contador = 0;         //cria uma variável integer chamada 'contador'
+int contador = 0;          //cria uma variável integer chamada 'contador'
 
 void setup() {
-  Serial.begin(9600);       // usa a porta serial para imprimir o número
+  Serial.begin(9600);      // usa a porta serial para imprimir o número
 }
 
 void loop() {
-  contador++;                // soma 1 ao int contador a cada execução do loop
-  Serial.println(contador);  // Imprime o estado atual do contador
-  delay(1000);              
+  contador++;               // soma 1 ao int contador a cada execução do loop
+  Serial.println(contador); // Imprime o estado atual do contador
+  delay(1000);
 }
 ----
 [%hardbreaks]

--- a/Language/Variables/Data Types/long.adoc
+++ b/Language/Variables/Data Types/long.adoc
@@ -41,7 +41,7 @@ Ao se fazer cálculos com inteiros, pelo menos um dos números deve ser seguido 
 
 [source,arduino]
 ----
-  long speedOfLight = 186000L;   // veja a página sobre constantes inteiras para uma explicação sobre o 'L'
+long speedOfLight = 186000L;  // veja a página sobre constantes inteiras para uma explicação sobre o 'L'
 ----
 
 --

--- a/Language/Variables/Data Types/short.adoc
+++ b/Language/Variables/Data Types/short.adoc
@@ -37,7 +37,7 @@ Em todos os Arduinos (baseados no ATMega ou ARM) um short armazena um valor 16-b
 
 [source,arduino]
 ----
- short ledPin = 13
+short ledPin = 13
 ----
 
 --

--- a/Language/Variables/Data Types/string.adoc
+++ b/Language/Variables/Data Types/string.adoc
@@ -22,7 +22,7 @@ Todos as declarações seguintes são válidas para strings.
 `char Str1[15];` +
 `char Str2[8] = {'a', 'r', 'd', 'u', 'i', 'n', 'o'};` +
 `char Str3[8] = {'a', 'r', 'd', 'u', 'i', 'n', 'o', '\0'};` +
-`char Str4[ ] = "arduino";` +
+`char Str4[] = "arduino";` +
 `char Str5[8] = "arduino";` +
 `char Str6[15] = "arduino";`
 
@@ -81,18 +81,19 @@ No código abaixo, o asterisco depois do tipo de dado `char` "`char*`" indica qu
 
 [source,arduino]
 ----
-char* myStrings[]={"This is string 1", "This is string 2", "This is string 3",
-"This is string 4", "This is string 5","This is string 6"};
+char *myStrings[] = {"This is string 1", "This is string 2", "This is string 3",
+                     "This is string 4", "This is string 5", "This is string 6"
+                    };
 
-void setup(){
-Serial.begin(9600);
+void setup() {
+  Serial.begin(9600);
 }
 
-void loop(){
-for (int i = 0; i < 6; i++){
-   Serial.println(myStrings[i]);
-   delay(500);
-   }
+void loop() {
+  for (int i = 0; i < 6; i++) {
+    Serial.println(myStrings[i]);
+    delay(500);
+  }
 }
 ----
 

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -81,16 +81,16 @@ Uma instância da classe String.
 Todas a seguir são declarações válidas para Strings.
 [source,arduino]
 ----
-String stringOne = "Hello String";                     // usando uma string constante
-String stringOne =  String('a');                       // convertendo um caractere constante para uma String
-String stringTwo =  String("This is a string");        // convertendo uma string constante para um objeto String
-String stringOne =  String(stringTwo + " with more");  // concatenando duas strings
-String stringOne =  String(13);                        // usando um inteiro constante
-String stringOne =  String(analogRead(0), DEC);        // usando um int e uma base especificada (decimal)
-String stringOne =  String(45, HEX);                   // usando um int e uma base especificada (hexadecimal)
-String stringOne =  String(255, BIN);                  // usando um int e uma base especificada (binário)
-String stringOne =  String(millis(), DEC);             // usando um long e uma base especificada
-String stringOne =  String(5.698, 3);                  // usando um float e o número de casas decimais
+String stringOne = "Hello String";                    // usando uma string constante
+String stringOne = String('a');                       // convertendo um caractere constante para uma String
+String stringTwo = String("This is a string");        // convertendo uma string constante para um objeto String
+String stringOne = String(stringTwo + " with more");  // concatenando duas strings
+String stringOne = String(13);                        // usando um inteiro constante
+String stringOne = String(analogRead(0), DEC);        // usando um int e uma base especificada (decimal)
+String stringOne = String(45, HEX);                   // usando um int e uma base especificada (hexadecimal)
+String stringOne = String(255, BIN);                  // usando um int e uma base especificada (binário)
+String stringOne = String(millis(), DEC);             // usando um long e uma base especificada
+String stringOne = String(5.698, 3);                  // usando um float e o número de casas decimais
 ----
 
 --

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -40,7 +40,7 @@ O trecho de código abaixo cria uma variável unsigned int chamada ledPin e a at
 
 [source,arduino]
 ----
-  unsigned int ledPin = 13;
+unsigned int ledPin = 13;
 ----
 [%hardbreaks]
 
@@ -51,9 +51,9 @@ Quando variáveis unsigned tem sua capacidade máxima excedida, elas "estouram" 
 [source,arduino]
 ----
 unsigned int x;
-   x = 0;
-   x = x - 1;       // x agora contém 65535
-   x = x + 1;       // x agora contém 0
+x = 0;
+x = x - 1;  // x agora contém 65535
+x = x + 1;  // x agora contém 0
 ----
 
 A matemática com variávies `unsigned` pode produzir resultados inesperados, mesmo se a variável `unsigned` nunca estourar.
@@ -67,16 +67,16 @@ No entanto, em um cálculo que requer um resultado intermediário, o escopo da v
 
 [source,arduino]
 ----
-unsigned int x=5;
-unsigned int y=10;
+unsigned int x = 5;
+unsigned int y = 10;
 int resultado;
 
-   resultado = x - y; // 5 - 10 = -5, como esperado
-   resultado = (x - y)/2; // 5 - 10 com matemática unsigned é 65530!  65530/2 = 32765 
-   
-   // solução: usar variáveis com sinal, ou fazer o cálculo passo a passo.
-   resultado = x - y; // 5 - 10 = -5, como esperado
-   resultado = resultado / 2; //  -5/2 = -2 (matemática inteira, casas decimais não são consideradas)
+resultado = x - y;  // 5 - 10 = -5, como esperado
+resultado = (x - y) / 2;  // 5 - 10 com matemática unsigned é 65530!  65530/2 = 32765
+
+// solução: usar variáveis com sinal, ou fazer o cálculo passo a passo.
+resultado = x - y;  // 5 - 10 = -5, como esperado
+resultado = resultado / 2;  //  -5/2 = -2 (matemática inteira, casas decimais não são consideradas)
 ----
 Então porque usar variáveis sem sinal?
 

--- a/Language/Variables/Data Types/unsignedLong.adoc
+++ b/Language/Variables/Data Types/unsignedLong.adoc
@@ -41,13 +41,11 @@ O código abaixo cria uma variável do tipo long para guardar o número de milis
 ----
 unsigned long time; //variável do tipo long
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
 }
 
-void loop()
-{
+void loop() {
   Serial.print("Time: ");
   time = millis();
   //imprime o tempo desde que o programa iniciou, em milissegundos

--- a/Language/Variables/Data Types/void.adoc
+++ b/Language/Variables/Data Types/void.adoc
@@ -34,13 +34,11 @@ O código mostra como usar a palavra chave `void`.
 // são realizadas ações nas funções "setup" e "loop"
 // porém não é retornada nenhuma informação quando as mesmas são executadas
 
-void setup()
-{
+void setup() {
   // ...
 }
 
-void loop()
-{
+void loop() {
   // ...
 }
 ----

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -29,7 +29,7 @@ O trecho de código abaixo cria uma variável do tipo word.
 
 [source,arduino]
 ----
-  word w = 10000;
+word w = 10000;
 ----
 
 --

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -34,9 +34,9 @@ Onde:
 
 Note que porque PROGMEM é um modificador de variável, não há uma regra rigorosa de onde ele deve ir, então o compilador aceita todos os tipos de definição abaixo, que também são sinônimos. Mesmo assim, experimentos indicaram que, em várias versões do Arduino (relacionado a versão do GCC), PROGMEM pode funcionar em uma localização e não em outra. O exemplo da "tabela de strings" abaixo foi testado com a versão 13 do Arduino. Versões mais antigas da IDE podem funcionar melhor se PROGMEM for incluído  depois do nome da variável.
 
-`const dataType variableName[] PROGMEM = {};   // use essa forma` +
-`const PROGMEM  dataType  variableName[] = {}; // ou essa` +
-`const dataType PROGMEM variableName[] = {};   // mas não essa`
+`const dataType variableName[] PROGMEM = {};  // use essa forma` +
+`const PROGMEM dataType variableName[] = {};  // ou essa` +
+`const dataType PROGMEM variableName[] = {};  // mas não essa`
 
 
 Enquanto `PROGMEM` pode ser usada em uma única variável, realmente só vale a pena o trabalho de usá-lo se você tiver um bloco de dados maior para ser armazenado, o que geralmente é mais fácil de fazer com vetores (ou outra estrutura de dados da linguagem C fora do escopo da nossa discussão atual).
@@ -62,13 +62,13 @@ Os fragmentos de código  abaixo ilustram como ler e escrever `unsigned chars` (
 [source,arduino]
 ----
 // armazena alguns unsigned ints
-const PROGMEM  uint16_t conjunto[]  = { 65000, 32796, 16843, 10, 11234};
+const PROGMEM uint16_t conjunto[] = {65000, 32796, 16843, 10, 11234};
 
 // armazena alguns chars
-const char mensagem[] PROGMEM  = {"Um pequeno jabuti xereta viu dez cegonhas felizes"};
+const char mensagem[] PROGMEM = {"Um pequeno jabuti xereta viu dez cegonhas felizes"};
 
 unsigned int displayInt;
-int k;    // vari[avel contadora
+int k;  // vari[avel contadora
 char meuChar;
 
 
@@ -77,17 +77,15 @@ void setup() {
   while (!Serial);  // Espera a porta serial conectar. Necessário para placas com USB nativa
 
   // Lê da memória flash um int (2-bytes, ou word)
-  for (k = 0; k < 5; k++)
-  {
+  for (k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(conjunto + k);
     Serial.println(displayInt);
   }
   Serial.println();
 
   // Lê um caractere da flash
-  for (k = 0; k < strlen_P(mensagem); k++)
-  {
-    meuCHar =  pgm_read_byte_near(mensagem + k);
+  for (k = 0; k < strlen_P(mensagem); k++) {
+    meuCHar = pgm_read_byte_near(mensagem + k);
     Serial.print(meuCHar);
   }
 
@@ -108,21 +106,21 @@ Essas estruturas tendem a ser muito grandes, de forma que colocá-las na memóri
 [source,arduino]
 ----
 /*
- demo com strings e PROGMEM
- Como armazenar uma tabela de strings na memória de programa (flash),
- e recuperá-los.
+  demo com strings e PROGMEM
+  Como armazenar uma tabela de strings na memória de programa (flash),
+  e recuperá-los.
 
- Informação resumida de:
- http://www.nongnu.org/avr-libc/user-manual/pgmspace.html
+  Informação resumida de:
+  http://www.nongnu.org/avr-libc/user-manual/pgmspace.html
 
- Preparar uma tabela (vetor) de strings na memória de programa é relativamente complicado,
- mas esse template pode ser seguido.
+  Preparar uma tabela (vetor) de strings na memória de programa é relativamente complicado,
+  mas esse template pode ser seguido.
 
- Preparar as strings é um processo em dois passos. O primeiro é definir as strings.
+  Preparar as strings é um processo em dois passos. O primeiro é definir as strings.
 */
 
 #include <avr/pgmspace.h>
-const char string_0[] PROGMEM = "String 0";   // "String 0" etc são as strings a serem armazenadas - adapte ao seu programa.
+const char string_0[] PROGMEM = "String 0"; // "String 0" etc são as strings a serem armazenadas - adapte ao seu programa.
 const char string_1[] PROGMEM = "String 1";
 const char string_2[] PROGMEM = "String 2";
 const char string_3[] PROGMEM = "String 3";
@@ -132,34 +130,30 @@ const char string_5[] PROGMEM = "String 5";
 
 // Então crie uma tabela para apontar para as suas strings.
 
-const char* const string_table[] PROGMEM = {string_0, string_1, string_2, string_3, string_4, string_5};
+const char *const string_table[] PROGMEM = {string_0, string_1, string_2, string_3, string_4, string_5};
 
-char buffer[30];    // Tenha certeza que esse buffer é grande o suficiente para armazenar a maior string
+char buffer[30];  // Tenha certeza que esse buffer é grande o suficiente para armazenar a maior string
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
-  while(!Serial); // Espera a porta serial conectar. Necessário para placas com USB nativa
+  while (!Serial);  // Espera a porta serial conectar. Necessário para placas com USB nativa
   Serial.println("OK");
 }
 
 
-void loop()
-{
+void loop() {
   /* Usar a tabela de strings da memória de programa requer o uso de funções especiais para recuperar os dados.
      A função strcpy_P copia uma string do espaço de programa para uma string na RAM (em um "buffer").
      Tenha certeza que o seu buffer na RAM é grande o suficiente para armazenar o que quer que seja
      que você estiver lendo da memória de programa. */
 
 
-  for (int i = 0; i < 6; i++)
-  {
-    strcpy_P(buffer, (char*)pgm_read_word(&(string_table[i]))); // Casts e desreferência necessários, apenas copie.
+  for (int i = 0; i < 6; i++) {
+    strcpy_P(buffer, (char *)pgm_read_word(&(string_table[i]))); // Casts e desreferência necessários, apenas copie.
     Serial.println(buffer);
-    delay( 500 );
+    delay(500);
   }
 }
-
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -49,18 +49,18 @@ O programa abaixo imprime um string um caractere de cada vez. Tente mudar o text
 char minhaStr[] = "Esse é um teste";
 int i;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  for (i = 0; i < sizeof(minhaStr) - 1; i++){
+  for (i = 0; i < sizeof(minhaStr) - 1; i++) {
     Serial.print(i, DEC);
     Serial.print(" = ");
     Serial.write(minhaStr[i]);
     Serial.println();
   }
-  delay(5000); // espera 5 segundos
+  delay(5000);  // espera 5 segundos
 }
 ----
 [%hardbreaks]
@@ -71,7 +71,7 @@ Note que `sizeof` retorna o número total de bytes. Então, para os tipos de dad
 
 [source,arduino]
 ----
-for (i = 0; i < (sizeof(meusInts)/sizeof(int)); i++) {
+for (i = 0; i < (sizeof(meusInts) / sizeof(int)); i++) {
   // faz algo com meusInts[i]
 }
 ----

--- a/Language/Variables/Variable Scope & Qualifiers/const.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/const.adoc
@@ -34,14 +34,9 @@ Constantes definidas com a palavra chave `const` obedecem as regras dos link:../
 ----
 const float pi = 3.14;
 float x;
-
 // ....
-
-x = pi * 2;    // constantes podem ser usadas em cálculos
-
-pi = 7;        // ilegal - você não pode modificar o valor de uma constante
-
-
+x = pi * 2; // constantes podem ser usadas em cálculos
+pi = 7; // ilegal - você não pode modificar o valor de uma constante
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Variable Scope & Qualifiers/scope.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/scope.adoc
@@ -41,21 +41,18 @@ Quando programas começam a ficar muito longos e complexos, variáveis locais s�
 ----
 int gPWMval;  // qualquer função poderá acessar essa variável
 
-void setup()
-{
+void setup() {
   // ...
 }
 
-void loop()
-{
+void loop() {
   int i;    // "i" é "visível" apenas dentro de "loop"
   float f;  // "f" é "visível" apenas dentro de "loop"
   // ...
 
-  for (int j = 0; j <100; j++){
+  for (int j = 0; j < 100; j++) {
     // a variável j pode ser acessada apenas dentro das chaves do loop for
   }
-
 }
 ----
 [%hardbreaks]

--- a/Language/Variables/Variable Scope & Qualifiers/static.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/static.adoc
@@ -34,12 +34,12 @@ Variáveis declaradas como static são criadas e inicializadas apenas a primeria
 [source,arduino]
 ----
 /* RandomWalk
-* Paul Badger 2007
-* RandomWalk wanders up and down randomly between two
-* endpoints. The maximum move in one loop is governed by
-* the parameter "stepsize".
-* A static variable is moved up and down a random amount.
-* This technique is also known as "pink noise" and "drunken walk".
+  Paul Badger 2007
+  RandomWalk wanders up and down randomly between two
+  endpoints. The maximum move in one loop is governed by
+  the parameter "stepsize".
+  A static variable is moved up and down a random amount.
+  This technique is also known as "pink noise" and "drunken walk".
 */
 
 #define randomWalkLowRange -20
@@ -49,29 +49,28 @@ int stepsize;
 int thisTime;
 int total;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
 }
 
-void loop()
-{        //  test randomWalk function
+void loop() {
+  //  test randomWalk function
   stepsize = 5;
   thisTime = randomWalk(stepsize);
   Serial.println(thisTime);
-   delay(10);
+  delay(10);
 }
 
-int randomWalk(int moveSize){
-  static int  place;     // variable to store value in random walk - declared static so that it stores
-                         // values in between function calls, but no other functions can change its value
+int randomWalk(int moveSize) {
+  static int place; // variable to store value in random walk - declared static so that it stores
+  // values in between function calls, but no other functions can change its value
 
   place = place + (random(-moveSize, moveSize + 1));
 
-  if (place < randomWalkLowRange){                              // check lower and upper limits
-    place = randomWalkLowRange + (randomWalkLowRange - place);  // reflect number back in positive direction
+  if (place < randomWalkLowRange) {                               // check lower and upper limits
+    place = randomWalkLowRange + (randomWalkLowRange - place);    // reflect number back in positive direction
   }
-  else if(place > randomWalkHighRange){
+  else if (place > randomWalkHighRange) {
     place = randomWalkHighRange - (place - randomWalkHighRange);  // reflect number back in negative direction
   }
 

--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -57,19 +57,16 @@ Há algumas formas de se fazer isso:
 int pin = 13;
 volatile int state = LOW;
 
-void setup()
-{
+void setup() {
   pinMode(pin, OUTPUT);
   attachInterrupt(digitalPinToInterrupt(2), blink, CHANGE);
 }
 
-void loop()
-{
+void loop() {
   digitalWrite(pin, state);
 }
 
-void blink()
-{
+void blink() {
   state = !state;
 }
 
@@ -78,12 +75,12 @@ void blink()
 
 [source,arduino]
 ----
-#include <util/atomic.h> // essa biblioteca inclui a macro ATOMIC_BLOCK.
+#include <util/atomic.h>  // essa biblioteca inclui a macro ATOMIC_BLOCK.
 
 
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-     // código com interrupções bloqueadas (operações atômicas consecutivas não irão ser interrompidas)
-  }
+ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+  // código com interrupções bloqueadas (operações atômicas consecutivas não irão ser interrompidas)
+}
 
 
 ----


### PR DESCRIPTION
Inconsistent code formatting is confusing to beginners who may not understand which code differences are purely aesthetic. Inconsistency also breeds more inconsistency and inefficiency as contributers of example code struggle to determine any style convention to follow in their work.

AStyle (the tool used for the Arduino IDE's Auto Format feature) was used to automatically format the example code in the reference pages according to the standard Arduino style established in the official example sketches bundled with the Arduino IDE. The Auto Format formatting settings were used in addition to Arduino example formatter configuration:
https://github.com/arduino/Arduino/blob/1.8.8/build/shared/examples_formatter.conf
I used the latest version of AStyle, which offers some new configuration settings that allow enhanced compliance with the Arduino code style:

mode=c

style=attach

break-closing-braces
attach-closing-while
attach-namespaces
attach-classes
attach-inlines
attach-extern-c

indent=spaces=2
indent-classes
indent-switches
indent-cases
indent-col1-comments
indent-modifiers
indent-namespaces
indent-labels
indent-preproc-define

pad-header
pad-oper
unpad-paren

add-braces

remove-comment-prefix
convert-tabs
align-pointer=name

---
Fixes https://github.com/arduino/reference-pt/issues/299