### PR TITLE
Always use capital s when referring to String objects

### DIFF
--- a/Language/Variables/Data Types/String/Functions/toDouble.adoc
+++ b/Language/Variables/Data Types/String/Functions/toDouble.adoc
@@ -21,13 +21,11 @@ Converte uma String válida para um double. A String fornecida deve começar com
 [float]
 === Sintaxe
 [source,arduino]
-----
-string.toDouble()
-----
+`minhaString.toDouble()`
 
 [float]
 === Parâmetros
-`string`: uma variável do tipo String
+`minhaString`: uma variável do tipo String
 
 
 [float]


### PR DESCRIPTION
Beginners are frequently confused about String vs strings so it's important to make a clear distinction between the two in the documentation.

This is an extension of https://github.com/arduino/reference-pt/pull/267, which was not able to affect the `toDouble` reference page since it didn't exist at that time.

Fixes #233