### PR TITLE
Fix formatting of example link on toDouble page

### DIFF
--- a/Language/Variables/Data Types/String/Functions/toDouble.adoc
+++ b/Language/Variables/Data Types/String/Functions/toDouble.adoc
@@ -52,6 +52,6 @@ Se não foi possível realizar uma conversão válida, porque a String não come
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^]
+* #EXEMPLO# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Tutoriais String (Em Inglês)^]
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
The space between link: and the URL caused the "link:" to be shown as text on the page. Since all the other example links do not use the link: markup, I removed it from the incorrectly formatted links.

Fixes https://github.com/arduino/reference-pt/issues/241