### PR TITLE
Convert toDouble page from UTF-8 BOM to UTF-8 encoding

### DIFF
--- a/Language/Variables/Data Types/String/Functions/toDouble.adoc
+++ b/Language/Variables/Data Types/String/Functions/toDouble.adoc
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "toDouble()"
 categories: [ "Data Types" ]
 subCategories: [ "StringObject Function" ]


### PR DESCRIPTION
This is an extension of https://github.com/arduino/reference-pt/pull/306, which was not able to affect the `toDouble` reference page since it didn't exist at that time.

Fixes #296