### PR TITLE
Document Stream.getTimeout()

### DIFF
--- a/Language/Functions/Communication/Serial/getTimeout.adoc
+++ b/Language/Functions/Communication/Serial/getTimeout.adoc
@@ -1,0 +1,60 @@
+---
+title: Serial.getTimeout()
+---
+
+
+
+
+= Serial.getTimeout()
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+`Serial.getTimeout()` returns the timeout value set by `Serial.setTimeout()`.
+
+`Serial.getTimeout()` inherits from the link:../../stream[Stream] utility class.
+[%hardbreaks]
+
+
+[float]
+=== Syntax
+`_Serial_.getTimeout()`
+
+[float]
+=== Parameters
+None
+
+[float]
+=== Returns
+The timeout value set by `Serial.setTimeout()` (unsigned long)
+
+--
+// OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+--
+// HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="language"]
+* #LANGUAGE# link:../../stream[stream]
+* #LANGUAGE# link:../../stream/streamsettimeout[stream.setTimeout()]
+* #LANGUAGE# link:../../stream/streamgettimeout[stream.getTimeout()]
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Communication/Serial/getTimeout.adoc
+++ b/Language/Functions/Communication/Serial/getTimeout.adoc
@@ -2,35 +2,31 @@
 title: Serial.getTimeout()
 ---
 
-
-
-
 = Serial.getTimeout()
-
 
 // OVERVIEW SECTION STARTS
 [#overview]
 --
 
 [float]
-=== Description
-`Serial.getTimeout()` returns the timeout value set by `Serial.setTimeout()`.
+=== Descrição
+`Serial.getTimeout()` retorna o valor de tempo limite configurado por `Serial.setTimeout()`.
 
-`Serial.getTimeout()` inherits from the link:../../stream[Stream] utility class.
+`Serial.getTimeout()` herda da classe link:../../stream[Stream].
 [%hardbreaks]
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `_Serial_.getTimeout()`
 
 [float]
-=== Parameters
-None
+=== Parâmetros
+Nenhum
 
 [float]
-=== Returns
-The timeout value set by `Serial.setTimeout()` (unsigned long)
+=== Retorna
+O tempo limite configurado por `Serial.setTimeout()` (unsigned long)
 
 --
 // OVERVIEW SECTION ENDS
@@ -49,7 +45,7 @@ The timeout value set by `Serial.setTimeout()` (unsigned long)
 --
 
 [float]
-=== See also
+=== Ver Também
 
 [role="language"]
 * #LANGUAGE# link:../../stream[stream]

--- a/Language/Functions/Communication/Stream/streamGetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamGetTimeout.adoc
@@ -1,0 +1,43 @@
+---
+title: Stream.getTimeout()
+---
+
+
+
+
+= getTimeout()
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+`getTimeout()` returns the timeout value set by `setTimeout()`. This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+[%hardbreaks]
+
+
+[float]
+=== Syntax
+`stream.getTimeout()`
+
+
+[float]
+=== Parameters
+None
+
+[float]
+=== Returns
+The timeout value set by `stream.setTimeout()` (unsigned long)
+
+--
+// OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+--
+// HOW TO USE SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamGetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamGetTimeout.adoc
@@ -2,34 +2,30 @@
 title: Stream.getTimeout()
 ---
 
-
-
-
 = getTimeout()
-
 
 // OVERVIEW SECTION STARTS
 [#overview]
 --
 
 [float]
-=== Description
-`getTimeout()` returns the timeout value set by `setTimeout()`. This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+=== Descrição
+`getTimeout()` retorna o valor de tempo limite configrado por `setTimeout()`. Essa função é parte da classe Stream, e é chamada por qualquer classe the herde da mesma (Wire, Serial, etc). Veja a página principal da link:../../stream[classe Stream] para mais informações.
 [%hardbreaks]
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `stream.getTimeout()`
 
 
 [float]
-=== Parameters
-None
+=== Parâmetros
+Nenhum
 
 [float]
-=== Returns
-The timeout value set by `stream.setTimeout()` (unsigned long)
+=== Retorna
+O valor do tempo limite configurado por `stream.setTimeout()` (unsigned long)
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
Fixes #251.
Update from the English repository.