### PR TITLE
Add Yun to the list of the boards serialEvent() doesn't work for

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -58,7 +58,7 @@ Nada
 
 [float]
 === Notas e Advertências
-`serialEvent()` não funciona no Leonardo ou Micro.
+`serialEvent()` não funciona no Leonardo, Micro ou Yún.
 
 `serialEvent()` e `serialEvent1()` não funcionam nas placas Arduino SAMD.
 


### PR DESCRIPTION
Fixes #277.
Update from the English repository.