### PR TITLE
Document syntax for data types where missing

### DIFF
--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -18,14 +18,14 @@ O tipo `bool` pode armazenar dois valores: `true` or `false`. (Cada variável `b
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `bool var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -16,6 +16,17 @@ O tipo `bool` pode armazenar dois valores: `true` or `false`. (Cada variável `b
 
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`bool var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/byte.adoc
+++ b/Language/Variables/Data Types/byte.adoc
@@ -15,6 +15,17 @@ subCategories: [ "Tipos de Dados" ]
 Uma variável 'byte' armazena valores numéricos de 8-bit sem sinal, de 0 a 255.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`byte var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/byte.adoc
+++ b/Language/Variables/Data Types/byte.adoc
@@ -17,14 +17,14 @@ Uma variável 'byte' armazena valores numéricos de 8-bit sem sinal, de 0 a 255.
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `byte var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável 
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -19,6 +19,17 @@ No entanto, caracteres são armazenados como números. Você pode ver a codifica
 O tipo de dado char é um tipo com sinal, armazenando números de -128 a 127. Para um tipo de dado sem sinal, de um byte (8 bits), use o tipo de dado _byte_.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`char var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -21,14 +21,14 @@ O tipo de dado char é um tipo com sinal, armazenando números de -128 a 127. Pa
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `char var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/double.adoc
+++ b/Language/Variables/Data Types/double.adoc
@@ -17,6 +17,17 @@ Número de Ponto flutuante Double. No UNO e outras placas baseadas no ATMEGA, oc
 No Arduino Due e outras placas com SAMD, doubles usam 8 bytes, ou seja, precisão de 64 bits.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`double var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/double.adoc
+++ b/Language/Variables/Data Types/double.adoc
@@ -19,14 +19,14 @@ No Arduino Due e outras placas com SAMD, doubles usam 8 bytes, ou seja, precisã
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `double var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/float.adoc
+++ b/Language/Variables/Data Types/float.adoc
@@ -25,10 +25,13 @@ Quando fizer cálculos com floats, você precisa adicionar um ponto decimal, do 
 
 [float]
 === Sintaxe
-`float var=val`
+`float var = val`
 
-`var` - o nome da sua variável float
-`val` - o valor a ser dado a variável
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
+
 [%hardbreaks]
 
 --

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -27,8 +27,10 @@ O Arduino cuida dos detalhes nas operações com números negativos por você, t
 === Sintaxe
 `int var = val;`
 
-`var` - o nome da sua variável int +
-`val` - o valor a ser dado a variável
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/long.adoc
+++ b/Language/Variables/Data Types/long.adoc
@@ -20,11 +20,12 @@ Ao se fazer cálculos com inteiros, pelo menos um dos números deve ser seguido 
 
 [float]
 === Sintaxe
-
 `long var = val;`
 
-`var` - o nome da variável long
-`val` - o valor dado à variável
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 [%hardbreaks]
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/short.adoc
+++ b/Language/Variables/Data Types/short.adoc
@@ -21,8 +21,10 @@ Em todos os Arduinos (baseados no ATMega ou ARM) um short armazena um valor 16-b
 === Sintaxe
 `short var = val;`
 
-`var` - o nome da sua variável short
-`val` - o valor a ser dado a variável
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/size_t.adoc
+++ b/Language/Variables/Data Types/size_t.adoc
@@ -17,15 +17,14 @@ subCategories: [ "Data Types" ]
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `size_t var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
-
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/size_t.adoc
+++ b/Language/Variables/Data Types/size_t.adoc
@@ -15,6 +15,17 @@ subCategories: [ "Data Types" ]
 `size_t` é um tipo de dado capaz de representar o tamanho de qualquer objeto em bytes. Exemplos do uso de `size_t` são o tipo do retorno de link:../../utilities/sizeof[sizeof()] e link:../../../functions/communication/serial/print[Serial.print()].
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`size_t var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/unsignedChar.adoc
+++ b/Language/Variables/Data Types/unsignedChar.adoc
@@ -18,6 +18,17 @@ Um tipo de dado sem sinal, que ocupa um byte na memória. O mesmo que o tipo de 
 Para consistência do estilo de programação Arduino, o tipo de dado byte é preferido.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`unsigned char var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/unsignedChar.adoc
+++ b/Language/Variables/Data Types/unsignedChar.adoc
@@ -20,14 +20,14 @@ Para consistência do estilo de programação Arduino, o tipo de dado byte é pr
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `unsigned char var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -25,8 +25,11 @@ A diferença entre unsigned ints e ints (com sinal), está na forma como o bit m
 [float]
 === Sintaxe
 `unsigned int var = val;`
-`var` - o nome da sua variável unsigned int
-`val` - o valor a ser dado a variável
+
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 
 // HOW TO USE SECTION STARTS

--- a/Language/Variables/Data Types/unsignedLong.adoc
+++ b/Language/Variables/Data Types/unsignedLong.adoc
@@ -17,11 +17,12 @@ Variáveis unsigned long são variáveis de tamanho extendido para armazenamento
 
 [float]
 === Sintaxe
-
 `unsigned long var = val;`
 
-`var` - o nome da sua variável long
-`val` - o valor a ser dado a variável
+
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 [%hardbreaks]
 
 --

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -15,6 +15,17 @@ subCategories: [ "Tipos de Dados" ]
 Uma variável word armazena um número sem sinal de 16 bits, de 0 A 65535. O mesmo que uma variável unsigned int.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`word var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -17,14 +17,14 @@ Uma variável word armazena um número sem sinal de 16 bits, de 0 A 65535. O mes
 
 
 [float]
-=== Syntax
+=== Sintaxe
 `word var = val;`
 
 
 [float]
-=== Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+=== Parâmetros
+`var`: nome da variável +
+`val`: valor a ser atribuído à variável
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
Fixes #293.
Update from English repository.