### PR TITLE
Declare counter variable in for statements

### DIFF
--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -28,7 +28,7 @@ No códgo seguinte, o break quebra o loop `for` quando o valor do sensor excede 
 [source,arduino]
 ----
 int lim = 40;
-for (x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x ++) {
   analogWrite(PWMpin, x);
   sens = analogRead(sensorPin);
   if (sens > lim) { // "foge" do o loop `for`

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -31,7 +31,7 @@ O comando `continue` "pula" o resto da iteração atual de um loop (link:../for[
 O código abaixo escreve o valor de 0 a 255 ao pino `PWMpin`, mas pula os valores no intervalo 41 a 119.
 [source,arduino]
 ----
-for (x = 0; x <= 255; x ++) {
+for (int x = 0; x <= 255; x ++) {
   if (x > 40 && x < 120) {  // cria um salto nos valores
     continue;
   }

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -69,8 +69,7 @@ Vetores são frequentemente manipulados dentro de loops `for`, onde o contador d
 
 [source,arduino]
 ----
-int i;
-for (i = 0; i < 5; i = i + 1) {
+for (byte i = 0; i < 5; i = i + 1) {
   Serial.println(meusPinos[i]);
 }
 ----

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -68,7 +68,6 @@ const PROGMEM uint16_t conjunto[] = {65000, 32796, 16843, 10, 11234};
 const char mensagem[] PROGMEM = {"Um pequeno jabuti xereta viu dez cegonhas felizes"};
 
 unsigned int displayInt;
-int k;  // vari[avel contadora
 char meuChar;
 
 
@@ -77,14 +76,14 @@ void setup() {
   while (!Serial);  // Espera a porta serial conectar. Necessário para placas com USB nativa
 
   // Lê da memória flash um int (2-bytes, ou word)
-  for (k = 0; k < 5; k++) {
+  for (byte k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(conjunto + k);
     Serial.println(displayInt);
   }
   Serial.println();
 
   // Lê um caractere da flash
-  for (k = 0; k < strlen_P(mensagem); k++) {
+  for (byte k = 0; k < strlen_P(mensagem); k++) {
     meuCHar = pgm_read_byte_near(mensagem + k);
     Serial.print(meuCHar);
   }

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -47,14 +47,13 @@ O programa abaixo imprime um string um caractere de cada vez. Tente mudar o text
 [source,arduino]
 ----
 char minhaStr[] = "Esse é um teste";
-int i;
 
 void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  for (i = 0; i < sizeof(minhaStr) - 1; i++) {
+  for (byte i = 0; i < sizeof(minhaStr) - 1; i++) {
     Serial.print(i, DEC);
     Serial.print(" = ");
     Serial.write(minhaStr[i]);
@@ -74,7 +73,7 @@ Note que `sizeof` retorna o número total de bytes. Então, para vetores de tipo
 int meusValores[] = {123, 456, 789};
 
 // this for loop works correctly with an array of any type or size
-for (i = 0; i < (sizeof(meusValores)/sizeof(meusValores[0])); i++) {
+for (byte i = 0; i < (sizeof(meusValores)/sizeof(meusValores[0])); i++) {
   // fazer algo com meusValores[i]
 }
 ----


### PR DESCRIPTION
Declaring the counter variable outside the for statement is done very rarely in actual programming, and only when there is a use for that variable outside the scope of the for loop (which is not the case here). I don't see any value in declaring the variable outside the statement in the example code, as it only teaches bad programming. In some cases, the example code snippets didn't even contain a declaration and so would not compile if copied into a sketch.

Fixes https://github.com/arduino/reference-pt/issues/348