### PR TITLE
Fix inconsistent formatting of See also links

### DIFF
--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -63,7 +63,7 @@ while (var < 200) {
 [role="language"]
 
 [role="example"]
-#EXEMPLO#	https://arduino.cc/en/Tutorial/WhileLoop[Tutorial Loop While (Em Inglês)^]
+#EXEMPLO# https://arduino.cc/en/Tutorial/WhileLoop[Tutorial Loop While (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -82,8 +82,8 @@ Similarmente, incluir sinal de igual após #define também resultará em erros
 === Ver Também
 
 [role="language"]
-#LINGUAGEM#	link:../../../variables/variable-scope\--qualifiers/const[palavra-chave const] +
-#LINGUAGEM#	link:../../../variables/constants/constants[Constantes]
+#LINGUAGEM# link:../../../variables/variable-scope\--qualifiers/const[palavra-chave const] +
+#LINGUAGEM# link:../../../variables/constants/constants[Constantes]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
These links use a tab separator between the tag and link, contrary to the standard established in the reference sample.

Fixes https://github.com/arduino/reference-pt/issues/349