### PR TITLE
Fix link to PitchFollower tutorial

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -78,7 +78,7 @@ Se você quiser tocar tons diferentes em múltiplos pinos, você precisa chamar 
 
 [role="example"]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/Tone[Tone^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone[Pitch follower^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch follower^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/PWM[PWM^]


### PR DESCRIPTION
Previously, the link pointed to the ToneMelody tutorial, which already has a link on the tone reference page.

Fixes https://github.com/arduino/reference-pt/issues/352