### PR TITLE
Fix formatting of example code

### DIFF
--- a/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
+++ b/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
@@ -105,8 +105,8 @@ This is `code` in a sentence +
 This can be a lot more code 
 [source,arduino]
 ----
-for (int 1; i<=99; i++) {
-	Serial.println('We want more code!');
+for (int i = 0; i <= 99; i++) {
+  Serial.println('We want more code!');
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -28,7 +28,7 @@ No códgo seguinte, o break quebra o loop `for` quando o valor do sensor excede 
 [source,arduino]
 ----
 int lim = 40;
-for (x = 0; x < 255; x ++) {
+for (x = 0; x < 255; x++) {
   analogWrite(PWMpin, x);
   sens = analogRead(sensorPin);
   if (sens > lim) { // "foge" do o loop `for`


### PR DESCRIPTION
Fix formatting issues which were not covered by the auto format.

Fix formatting issues in AsciiDoc_Template-Dictionary.adoc, which I accidentally skipped during the auto format.

Fixes https://github.com/arduino/reference-pt/issues/353