### PR TITLE
Use a single space after period

### DIFF
--- a/Language/Structure/Pointer Access Operators/reference.adoc
+++ b/Language/Structure/Pointer Access Operators/reference.adoc
@@ -14,7 +14,7 @@ subCategories: [ "Operadores para Ponteiros" ]
 
 [float]
 === Descrição
-Referência é uma das características da linguagem C para uso especificamente com ponteiros.  O operador `&` ('e' comercial ou ampersand) é utilizado para esse propósito. Se `x` é uma variável, então `&x` representa o endereço da variável `x`.
+Referência é uma das características da linguagem C para uso especificamente com ponteiros. O operador `&` ('e' comercial ou ampersand) é utilizado para esse propósito. Se `x` é uma variável, então `&x` representa o endereço da variável `x`.
 [%hardbreaks]
 
 --

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -13,7 +13,7 @@ subCategories: [ "StringObject Operator" ]
 
 [float]
 === Descrição
-Testa se a String à esquerda é menor que a String à direita. Esse operador avalia Strings em ordem alfabética, no primeiro caractere no qual as duas diferem.  Então, por exemplo "a" < "b" e "1" < "2", mas "999" > "1000" porque 9 vem depois de 1.
+Testa se a String à esquerda é menor que a String à direita. Esse operador avalia Strings em ordem alfabética, no primeiro caractere no qual as duas diferem. Então, por exemplo "a" < "b" e "1" < "2", mas "999" > "1000" porque 9 vem depois de 1.
 
 Cuidado: Operadores de comparação de Strings podem ser confusos quando você está comparando Strings numéricas, porque os numerais são tratados como strings e não números. Se você precisa comparar números numericamente, compare-os como ints, floats ou longs, e não como Strings.
 

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -64,7 +64,7 @@ void loop() {
 
 [float]
 === Notas e Advertências
-Quando variáveis com  sinal são forçadas a exceder sua capacidade máxima ou mínima, elas _estouram_; ou do Inglês, sofrem _overflow_.  O resultado de um overflow é imprevisível, então isso deve ser evitado.  Um sintoma típico de um overflow é a variável "rolar" de sua capacidade máxima para a mínima ou vice-versa, mas não é sempre o caso.  Se você deseja esse comportamento, use o tipo link:../unsignedint/[unsigned int].
+Quando variáveis com  sinal são forçadas a exceder sua capacidade máxima ou mínima, elas _estouram_; ou do Inglês, sofrem _overflow_. O resultado de um overflow é imprevisível, então isso deve ser evitado. Um sintoma típico de um overflow é a variável "rolar" de sua capacidade máxima para a mínima ou vice-versa, mas não é sempre o caso. Se você deseja esse comportamento, use o tipo link:../unsignedint/[unsigned int].
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
Following the standard established by the reference sample pages.

Fixes https://github.com/arduino/reference-pt/issues/354