### PR TITLE
Update links to tone tutorials

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -77,10 +77,10 @@ Se você quiser tocar tons diferentes em múltiplos pinos, você precisa chamar 
 * #LINGUAGEM# link:../../analog-io/analogwrite[analogWrite()]
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone[Tone^]
+* #EXEMPLO# https://www.arduino.cc/en/Tutorial/toneMelody[Tone^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch follower^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
+* #EXEMPLO# https://www.arduino.cc/en/Tutorial/toneKeyboard[Simple Keyboard^]
+* #EXEMPLO# https://www.arduino.cc/en/Tutorial/toneMultiple[multiple tones^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/PWM[PWM^]
 
 --


### PR DESCRIPTION
The tone tutorial links use outdated URLs that must redirect to the current URLs. It's better to point the links directly to the correct URL.

Fixes https://github.com/arduino/reference-pt/issues/364