### PR TITLE
Standardize link text

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -77,10 +77,10 @@ Se você quiser tocar tons diferentes em múltiplos pinos, você precisa chamar 
 * #LINGUAGEM# link:../../analog-io/analogwrite[analogWrite()]
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone[Tone^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch follower^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone[Tone Melody^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch Follower^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone3[Tone Keyboard^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/Tone4[Tone Multiple^]
 * #EXEMPLO# http://arduino.cc/en/Tutorial/PWM[PWM^]
 
 --

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -77,7 +77,7 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent Tutorial (Em Inglês)^] +
+#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[Serial Event Tutorial (Em Inglês)^] +
 
 [role="language"]
 #LINGUAGEM# link:../begin[begin()] +


### PR DESCRIPTION
I'm following the example of the Tutorials page in how to format the link text for the tutorial links.

Fixes https://github.com/arduino/reference-pt/issues/369