### PR TITLE
Be consistent with the use of "Tutorial" in link text

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -77,7 +77,7 @@ Nada
 === Ver Também
 
 [role="example"]
-#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[Serial Event Tutorial (Em Inglês)^] +
+#EXEMPLO# http://arduino.cc/en/Tutorial/SerialEvent[Serial Event (Em Inglês)^] +
 
 [role="language"]
 #LINGUAGEM# link:../begin[begin()] +

--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -63,7 +63,7 @@ while (var < 200) {
 [role="language"]
 
 [role="example"]
-#EXEMPLO# https://arduino.cc/en/Tutorial/WhileLoop[Tutorial Loop While (Em Inglês)^]
+#EXEMPLO# https://arduino.cc/en/Tutorial/WhileLoop[Loop While (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
These two tutorial links are no different from the many other example links on the other reference pages, yet they have the word "Tutorial" added, contrary to the standard established in the reference samples. There are some other instances of the use of "Tutorial" in the link text, but in those cases the link does lead to more of a general tutorial than a standard tutorial for an example sketch, so I have left those as is.

Fixes https://github.com/arduino/reference-pt/issues/383