### PR TITLE
Fix markup of bitWrite() example

### DIFF
--- a/Language/Functions/Bits and Bytes/bitWrite.adoc
+++ b/Language/Functions/Bits and Bytes/bitWrite.adoc
@@ -46,6 +46,7 @@ Nada
 O código a seguir demonstra o use de bitWrite ao imprimir uma variável no Monitor Serial antes e depois do uso de `bitWrite()`.
 
 [source,arduino]
+----
 void setup() {
   Serial.begin(9600);
   while (!Serial) {}  // espera a porta serial conectar. Necessário apenas em placas com USB nativa


### PR DESCRIPTION
Incorrect markup caused part of the example code to be outside the code block:

![Clipboard01](https://user-images.githubusercontent.com/8572152/57335453-85685e80-70d7-11e9-9ed3-b038780b5fb0.png)

Fixes https://github.com/arduino/reference-pt/issues/384