### PR TITLE
Add missing "See also" section to stream reference page

### DIFF
--- a/Language/Functions/Communication/stream.adoc
+++ b/Language/Functions/Communication/stream.adoc
@@ -54,3 +54,14 @@ link:../stream/streamsettimeout[setTimeout()]
 
 --
 // FUNCTIONS SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== Ver Também
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
When the "See also" section is missing, the automatically generated links to the other pages within the same subsection are added to a section titled "undefined".

Fixes https://github.com/arduino/reference-pt/issues/396