### PR TITLE
Fix asciidoc markup errors

### DIFF
--- a/Language/Functions/Communication/Serial/println.adoc
+++ b/Language/Functions/Communication/Serial/println.adoc
@@ -30,6 +30,8 @@ Imprime dados na porta serial como texto ASCII seguido pelo caratere de retorno 
 [float]
 === Retorna
 `size_t`: `println()` retorna o número de bytes escritos, porém a leitura desse número é opcional
+
+--
 // OVERVIEW SECTION ENDS
 
 // HOW TO USE SECTION STARTS

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -76,6 +76,7 @@ void loop() {
 ----
 [%hardbreaks]
 
+--
 // HOW TO USE SECTION ENDS
 
 

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -22,7 +22,7 @@ Retorna uma substring de uma String. O índice do início é inclusivo (o caract
 === Sintaxe
 `minhaString.substring(inicio)` +
 `minhaString.substring(inicio, fim)`
-----
+
 
 [float]
 === Parâmetros

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -19,17 +19,19 @@ O Due e outras placas ARM armazenam um unsigned int em 4 bytes (32 bits), de 0 a
 A diferença entre unsigned ints e ints (com sinal), está na forma como o bit mais significativo, as vezes chamado de o bit "de sinal", é interpretado. No tipo int do Arduino (que possui sinal), se o bit mais significativo é "1", o número é interpretado como um número negativo, e os outros 15 bits são interpretados com (https://pt.wikipedia.org/wiki/Complemento_para_dois[complemento de 2]).
 [%hardbreaks]
 
---
-// OVERVIEW SECTION ENDS
 
 [float]
 === Sintaxe
 `unsigned int var = val;`
 
 
+[float]
 === Parâmetros
 `var`: nome da variável +
 `val`: valor a ser atribuído à variável
+
+--
+// OVERVIEW SECTION ENDS
 
 
 // HOW TO USE SECTION STARTS


### PR DESCRIPTION
These issues were reported by the site build tool:
```
ERROR 2019/06/07 22:34:31 asciidoctor: WARNING: Language/Functions/USB/Mouse/mouseRelease.adoc: line 92: unterminated open block
ERROR 2019/06/07 22:34:54 asciidoctor: WARNING: Language/Functions/Communication/Serial/println.adoc: line 75: unterminated open block
ERROR 2019/06/07 22:37:51 asciidoctor: WARNING: Language/Variables/Data Types/String/Functions/substring.adoc: line 19: unterminated listing block
ERROR 2019/06/07 22:38:08 asciidoctor: WARNING: Language/Variables/Data Types/unsignedInt.adoc: line 24: section title out of sequence: expected level 1, got level 2
```