### PR TITLE
Use consistent link text for digital/analog pins tutorial links

### DIFF
--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -99,6 +99,6 @@ Se o pino de entrada analógica não estiver conectado a nada, o valor retornado
 
 [role="language"]
 * #LINGUAGEM# link:../../zero-due-mkr-family/analogreadresolution[analogReadResolution()]
-* #LINGUAGEM# https://www.arduino.cc/en/Tutorial/AnalogInputPins[Tutorial: Pinos de entrada analógica (Em Inglês)^]
+* #EXEMPLO# https://www.arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos de entrada analógica (em inglês)^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -86,7 +86,7 @@ Alternativamente, você pode conectar a tensão de referência externa ao pino A
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos analógicos de entrada (Em Inglês)^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/AnalogInputPins[Descrição dos pinos de entrada analógica (Em Inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -84,7 +84,7 @@ Os pinos de entrada analógica podem ser também usados como pinos digitais, ref
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# Tutorial (Em Inglês): (http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins])
+* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Descrição dos pinos digitais (em inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -88,7 +88,7 @@ Os pinos de entrada analógica podem ser também usados como pinos digitais, ref
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Tutorial: Pinos digitais (Em Inglês)^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Descrição dos pinos digitais (em inglês)^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -84,7 +84,7 @@ Os pinos de entrada analógica podem ser também usados como pinos digitais, ref
 === Ver Também
 
 [role="example"]
-* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Descrição dos pinos em uma placa Arduino (em Inglês)^]
+* #EXEMPLO# http://arduino.cc/en/Tutorial/DigitalPins[Descrição dos pinos digitais (em inglês)^]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
Update from the English repository.
Fixes #367 