### PR TITLE
Correct syntax section of parseFloat() reference pages

### DIFF
--- a/Language/Functions/Communication/Serial/parseFloat.adoc
+++ b/Language/Functions/Communication/Serial/parseFloat.adoc
@@ -10,7 +10,7 @@ title: Serial.parseFloat()
 
 [float]
 === Descrição
-`Serial.parseFloat()` retorna o primeiro número válido de ponto flutuante do buffer serial. Caracteres que não são dígitos (ou o sinal de menos) são pulados. `parseFloat()` é terminada pelo primeiro caractere que não é um número de ponto flutuante. A função retorna se acabar o tempo limite (veja link:../settimeout[Serial.setTimeout()]).
+`Serial.parseFloat()` retorna o primeiro número válido de ponto flutuante do buffer serial. `parseFloat()` é terminada pelo primeiro caractere que não é um número de ponto flutuante. A função retorna se acabar o tempo limite (veja link:../settimeout[Serial.setTimeout()]).
 
 A função `Serial.parseFloat()` é herdada da classe link:../../stream[Stream].
 [%hardbreaks]
@@ -19,10 +19,19 @@ A função `Serial.parseFloat()` é herdada da classe link:../../stream[Stream].
 [float]
 === Sintaxe
 `_Serial_.parseFloat()`
+`_Serial_.parseFloat(lookahead)` +
+`_Serial_.parseFloat(lookahead, ignore)`
 
 [float]
 === Parâmetros
-`_Serial_`: objeto porta serial. Veja a lista de portas seriais disponíveis em cada placa no link:../../serial[Serial - Página principal]
+`_Serial_`: objeto porta serial. Veja a lista de portas seriais disponíveis em cada placa no link:../../serial[Serial - Página principal] +
+`lookahead`: the modo usado ao se procurar um número de ponto flutuate na stream. Tipos de dados permitidos: `LookaheadMode`. + Valores de `lookahead` pemitidos:
+
+* `SKIP_ALL`: Todos os caracteres exceto o sinal de menos (-), ponto decimal, ou numerais são ignorados durante a busca na stream por um número de ponto flutuante. Esse é o modo padrão.
+* `SKIP_NONE`: Nada é ignorado, e a stream não é tocada a menos que o primeiro caractere a espera seja válido.
+* `SKIP_WHITESPACE`: Apenas tabulações, espaços, feeds de linha ('\n'), e retornos de linha ('\r') são ignorados.
+
+`ignore`: usado para ignorar o caractere indicado durante a busca. Udado por exemplo para pular o separador de milhares. Tipos de dados permitidos: `char`
 
 [float]
 === Retorna

--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -14,21 +14,28 @@ title: Stream.parseFloat()
 
 [float]
 === Descrição
-`parseFloat()` retorna o primeiro número de ponto flutuante da posição atual. Caracteres iniciais que não são digitos (ou o sinal de menos) são ignorados. `parseFloat()` é terminada pelo primeiro caractere que não é um digito encontrado após o número. A função retorna se acabar o tempo limite (veja link:../streamsettimeout[Stream.setTimeout()]).
+`parseFloat()` retorna o primeiro número de ponto flutuante da posição atual. `parseFloat()` é terminada pelo primeiro caractere que não é um digito encontrado após o número. A função retorna se acabar o tempo limite (veja link:../streamsettimeout[Stream.setTimeout()]).
 
 Essa função é parte da classe Stream, e pode ser chamada por qualquer classe que herda da mesma (Wire, Serial, etc). Veja a página principal da link:../../stream[classe Stream] para mais informações.
 [%hardbreaks]
 
 [float]
 === Sintaxe
-`stream.parseFloat(list)`
-
+`stream.parseFloat()`
+`stream.parseFloat(lookahead)` +
+`stream.parseFloat(lookahead, ignore)`
 
 [float]
 === Parâmetros
 `stream` : uma instância de uma classe que herda da classe Stream.
+`lookahead`: the modo usado ao se procurar um número de ponto flutuate na stream. Tipos de dados permitidos: `LookaheadMode`. + Valores de `lookahead` pemitidos:
 
-`list` : a stream a ser checada por floats (`char`)
+* `SKIP_ALL`: Todos os caracteres exceto o sinal de menos (-), ponto decimal, ou numerais são ignorados durante a busca na stream por um número de ponto flutuante. Esse é o modo padrão.
+* `SKIP_NONE`: Nada é ignorado, e a stream não é tocada a menos que o primeiro caractere a espera seja válido.
+* `SKIP_WHITESPACE`: Apenas tabulações, espaços, feeds de linha (`'\n'`), e retornos de linha (`'\r'`) são ignorados.
+
+`ignore`: usado para ignorar o caractere indicado durante a busca. Udado por exemplo para pular o separador de milhares. Tipos de dados permitidos: `char`
+
 
 [float]
 === Retorna


### PR DESCRIPTION
Update from the English repository.
Fixes #381