### PR TITLE
fix: typo

### DIFF
--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -53,7 +53,7 @@ void setup() {
 }
 
 void loop() {
-  //porcede normalmente
+  //procede normalmente
 }
 ----
 


### PR DESCRIPTION
Fixed a small typo located at the ifSerial section of the documentation.